### PR TITLE
Update strongs

### DIFF
--- a/Kung Fu Man/library/entities/character.entity
+++ b/Kung Fu Man/library/entities/character.entity
@@ -29114,7 +29114,7 @@
     },
     {
       "$id": "86aeaf18-5079-45fa-a29c-38c7ad532628",
-      "code": "self.reactivateHitboxes();\r\nself.updateHitboxStats(0, {damage: 12, knockbackGrowth: 70, baseKnockback: 75, hitstop: -1, selfHitstop: -1, angle: 80});",
+      "code": "self.reactivateHitboxes();\r\nself.updateHitboxStats(0, {damage: 12, knockbackGrowth: 70, baseKnockback: 75, hitstop:-1, hitstopOffset:7, selfHitstop:-1, selfHitstopOffset:7, angle: 80});",
       "length": 30,
       "pluginMetadata": {
       },

--- a/Kung Fu Man/library/entities/character.entity
+++ b/Kung Fu Man/library/entities/character.entity
@@ -24400,7 +24400,7 @@
     },
     {
       "$id": "8ea43a61-acec-4a33-bc94-9c0ce1abac2b",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "40267a11-b422-42eb-ad34-b98d818795b0",
@@ -24420,7 +24420,7 @@
     },
     {
       "$id": "13861457-0955-461c-aa86-707e8b294df4",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "9c48cef2-1f7e-4560-99bc-faa463cd697b",
@@ -24430,7 +24430,7 @@
     },
     {
       "$id": "8b04ac4e-f1bc-49b2-bb40-9e7bfd05c23f",
-      "length": 4,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": "1141f8e7-28b0-411f-8148-00b2ec3bf12b",
@@ -24440,7 +24440,7 @@
     },
     {
       "$id": "645806e3-605b-43ac-bab2-ee547bbeb5dc",
-      "length": 6,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": "6cdf2ec2-722c-4ae2-a692-9a41fd723f0f",
@@ -24450,7 +24450,7 @@
     },
     {
       "$id": "2e0b0023-6b2a-4b0b-814d-a089b73d8b91",
-      "length": 3,
+      "length": 7,
       "pluginMetadata": {
       },
       "symbol": "74962df1-4900-4b32-b454-29ccc788e341",
@@ -24460,7 +24460,7 @@
     },
     {
       "$id": "e12a9e66-183f-4e31-a17e-31ee8aa119e2",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24480,7 +24480,7 @@
     },
     {
       "$id": "6677063e-31e7-4471-9e9f-cb93a8cebc99",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "93472135-c822-4c86-8021-1d56450fc778",
@@ -24490,7 +24490,7 @@
     },
     {
       "$id": "ce32c331-1407-4273-af39-d03258c04299",
-      "length": 4,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24500,7 +24500,7 @@
     },
     {
       "$id": "76860399-16e3-4411-a5f9-4c5e8032c009",
-      "length": 6,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24510,7 +24510,7 @@
     },
     {
       "$id": "0c1dd9e7-d961-4650-aed6-ce2b0567683a",
-      "length": 3,
+      "length": 7,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24520,7 +24520,7 @@
     },
     {
       "$id": "61d11082-70f4-48f8-a345-d177a811404c",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24540,7 +24540,7 @@
     },
     {
       "$id": "56d1e4fe-dd71-4d46-9d73-1b59a58f5fd9",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "6bc83ec5-ccfc-47a7-b814-52480c0753f2",
@@ -24550,7 +24550,7 @@
     },
     {
       "$id": "946c7179-da72-4f65-bec0-30e520cf8077",
-      "length": 4,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24560,7 +24560,7 @@
     },
     {
       "$id": "32b9094b-ef95-4b4a-8fd8-dabe6be64b17",
-      "length": 6,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24570,7 +24570,7 @@
     },
     {
       "$id": "cf1f3413-c716-4ed0-bc5c-e0b2f023fbff",
-      "length": 3,
+      "length": 7,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24580,7 +24580,7 @@
     },
     {
       "$id": "7fde6639-95ec-4008-a3e9-68227923b3b0",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "acdb7eca-835e-42c7-89b6-1d8faba89828",
@@ -24600,7 +24600,7 @@
     },
     {
       "$id": "418c5dc6-aa89-4f39-a73f-fc5d363f1bea",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "6e0f968a-b7e2-4826-b260-ca2cccdbc2b0",
@@ -24610,7 +24610,7 @@
     },
     {
       "$id": "5235807a-7a89-4258-8e7c-e2498af7a45b",
-      "length": 4,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": "8a759aeb-84c3-4100-a1d6-8d0a3d89ea64",
@@ -24620,7 +24620,7 @@
     },
     {
       "$id": "5dd9d137-cb63-437c-a8c8-ae95586e33f4",
-      "length": 6,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": "c499fe40-300a-409e-ba76-e70740fd387a",
@@ -24630,7 +24630,7 @@
     },
     {
       "$id": "27cdaf8d-ca72-41b5-a231-6e5fe66aa4b6",
-      "length": 3,
+      "length": 7,
       "pluginMetadata": {
       },
       "symbol": "808b1d2e-8334-4338-a57a-b7030e84f584",
@@ -24640,7 +24640,7 @@
     },
     {
       "$id": "a23d95b3-24a4-47c8-bf4e-c49f327215fa",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "ea6ebc32-7b02-451a-9b38-d7610b2ac79e",
@@ -24660,7 +24660,7 @@
     },
     {
       "$id": "d0082829-4b97-438e-8578-54f27939f9a0",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "ad386897-4b1d-4c30-a098-8bbc0637b31c",
@@ -24670,7 +24670,7 @@
     },
     {
       "$id": "89d67013-21bc-4de3-93ad-468eefb47054",
-      "length": 4,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": "16daecc1-bad6-4a5b-b7f9-67f1f55a0002",
@@ -24680,7 +24680,7 @@
     },
     {
       "$id": "67ee229c-22bc-44cc-8e96-ee053e22a50d",
-      "length": 6,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": "b5dfcd73-112c-4aec-8a39-51f70c56f6f0",
@@ -24690,7 +24690,7 @@
     },
     {
       "$id": "1f738243-2773-4bde-a38c-d2080737d59d",
-      "length": 3,
+      "length": 7,
       "pluginMetadata": {
       },
       "symbol": "f4fab461-6652-4b5f-ada9-9543b746a57c",
@@ -24700,7 +24700,7 @@
     },
     {
       "$id": "e109d936-593e-46dd-80a1-37c282bf1e9c",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "88ec5b94-aaee-4bc0-8cb6-3e59846227b5",
@@ -24720,7 +24720,7 @@
     },
     {
       "$id": "ed718aa4-e361-48fd-a877-83b60f0c25f0",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "a74448c7-f32c-42f4-9bc6-1d2c82a39735",
@@ -24730,7 +24730,7 @@
     },
     {
       "$id": "e92fe6f3-8fd9-452a-b23e-a563e0323348",
-      "length": 4,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": "a9156f52-cb54-4288-92be-8a7560536ce0",
@@ -24740,7 +24740,7 @@
     },
     {
       "$id": "580519d2-1726-4d81-b279-b8bc2abd836d",
-      "length": 6,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": "f257f974-3bc2-4d04-ac4f-4600f36e185b",
@@ -24750,7 +24750,7 @@
     },
     {
       "$id": "2ed4f376-5394-4eba-9f48-68fcdb320f8d",
-      "length": 3,
+      "length": 7,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24760,7 +24760,7 @@
     },
     {
       "$id": "0149a4c0-467b-4750-8fb6-c71c801e27e8",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24780,7 +24780,7 @@
     },
     {
       "$id": "ff18753e-3696-4db5-8e01-43dfdb6d565d",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "dd4a4ee4-776d-479a-9b69-68414c563ed6",
@@ -24790,7 +24790,7 @@
     },
     {
       "$id": "66f2f0e6-d951-4539-91fa-322a6ab3b5a9",
-      "length": 4,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24800,7 +24800,7 @@
     },
     {
       "$id": "85fa9401-9cd0-4d7c-8cb1-3b37b820331d",
-      "length": 6,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24810,7 +24810,7 @@
     },
     {
       "$id": "b1dd3888-6c46-400b-a285-acdfc1a90376",
-      "length": 3,
+      "length": 7,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24820,7 +24820,7 @@
     },
     {
       "$id": "92d5736c-6d11-4555-8098-06fc6a0762e3",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24840,7 +24840,7 @@
     },
     {
       "$id": "9b026de3-3c5e-42ae-a7a7-680bdac131c6",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "cf96a6f0-14ed-4a67-8341-18f8ff8b4368",
@@ -24850,7 +24850,7 @@
     },
     {
       "$id": "8229d2be-0ac1-4d0c-80e8-b9543e15f0ad",
-      "length": 4,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24860,7 +24860,7 @@
     },
     {
       "$id": "9bdbcf0e-8f72-4670-a647-b6e1e10b451e",
-      "length": 6,
+      "length": 9,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -24870,7 +24870,7 @@
     },
     {
       "$id": "d6d40342-a95e-41b8-a0d1-cc415fe30949",
-      "length": 3,
+      "length": 7,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25010,7 +25010,7 @@
     },
     {
       "$id": "c0deac0b-ac90-4e43-ac2a-1380cb0e8fbf",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": "b9df8bfc-647c-4269-b6e4-3743c1e5660c",
@@ -25020,7 +25020,7 @@
     },
     {
       "$id": "57a0a4c3-af54-432e-9b79-fdfd82ff111b",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "09802428-5f19-40a2-b813-54062153b4de",
@@ -25040,7 +25040,7 @@
     },
     {
       "$id": "be42fc0d-30a0-4d0a-ac24-564032b45ad8",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": "24e0733d-ae81-4587-ad36-8cac1811b6a7",
@@ -25050,7 +25050,7 @@
     },
     {
       "$id": "71b399e2-9583-45dc-b1c5-2d24a0e29f49",
-      "length": 3,
+      "length": 5,
       "pluginMetadata": {
       },
       "symbol": "67fc1bb6-672d-4659-9de7-84bfe9d5e740",
@@ -25060,7 +25060,7 @@
     },
     {
       "$id": "cad81673-2590-4b3e-bf24-9e75fd4d8181",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": "2dd6054c-0a77-4b6e-80f7-4885640fc3dc",
@@ -25080,7 +25080,7 @@
     },
     {
       "$id": "928a2e37-3fda-44cc-adaa-6403d336190a",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25090,7 +25090,7 @@
     },
     {
       "$id": "64165afb-e428-4212-a2d1-3a4b42044c72",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25110,7 +25110,7 @@
     },
     {
       "$id": "dd6f57d3-50c1-4a50-83b6-d9c1b17ff1f5",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25120,7 +25120,7 @@
     },
     {
       "$id": "f73a38b2-e8fe-4305-a35d-a843622d77de",
-      "length": 3,
+      "length": 5,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25130,7 +25130,7 @@
     },
     {
       "$id": "4f33bc50-7757-4867-993b-86aab70d3324",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25150,7 +25150,7 @@
     },
     {
       "$id": "de98ba14-f518-4cf3-b73b-459461515d35",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25160,7 +25160,7 @@
     },
     {
       "$id": "939b75f0-e1bd-4e01-91f7-4f7fabe1aa21",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25180,7 +25180,7 @@
     },
     {
       "$id": "36a630ad-7957-4722-b743-4305c7e4a834",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25190,7 +25190,7 @@
     },
     {
       "$id": "0346a8b4-2fc1-4d32-925b-c351549e02b6",
-      "length": 3,
+      "length": 5,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25200,7 +25200,7 @@
     },
     {
       "$id": "520918c0-5a91-4760-a132-47fa699a272c",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25220,7 +25220,7 @@
     },
     {
       "$id": "fcc71ca4-8e2f-47e9-a0c6-e4c8eb6f9905",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25230,7 +25230,7 @@
     },
     {
       "$id": "e05918e5-063f-4e35-99b8-d0f6e924d7a6",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25250,7 +25250,7 @@
     },
     {
       "$id": "21d737ac-bef8-4e5f-a2d6-063d1b5c8a71",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25260,7 +25260,7 @@
     },
     {
       "$id": "82b1871f-cb59-4624-8ad4-5f204bc91da0",
-      "length": 3,
+      "length": 5,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25270,7 +25270,7 @@
     },
     {
       "$id": "f27c16f8-9dc6-4636-8b69-42022c60968b",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25290,7 +25290,7 @@
     },
     {
       "$id": "1acc8ad7-0f0e-4a83-a1e1-f577fba6ea6b",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": "b329760f-d5d3-4d65-81f4-a640f5485112",
@@ -25300,7 +25300,7 @@
     },
     {
       "$id": "2926e0a8-507b-4544-9e4f-a5c724d031c4",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "51ccabd0-e767-4eed-8b49-1e2e816f1be3",
@@ -25320,7 +25320,7 @@
     },
     {
       "$id": "ad074674-eb2c-4533-a333-e9d44370ec0d",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": "ca163357-4282-47f3-831f-e7b8613e7b44",
@@ -25330,7 +25330,7 @@
     },
     {
       "$id": "5476dd40-0a88-437a-ad0e-a6545187b826",
-      "length": 3,
+      "length": 5,
       "pluginMetadata": {
       },
       "symbol": "90afa4e0-1ee8-44b9-82cb-1f271e9cfb53",
@@ -25340,7 +25340,7 @@
     },
     {
       "$id": "63c9c578-3311-42dd-9262-3b40ee7a8a2f",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": "c8fe13e7-6dad-43ec-b31f-cec1b12def8b",
@@ -25360,7 +25360,7 @@
     },
     {
       "$id": "54984e6e-dd93-4674-adb0-c2373746b712",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": "5291f237-4d01-4ad1-a43e-e4835be1cf8a",
@@ -25370,7 +25370,7 @@
     },
     {
       "$id": "465a0a88-3ac3-4221-bc87-ca4ccc49e75d",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "fa906bf7-c853-43dc-a9e1-9301afb86e43",
@@ -25390,7 +25390,7 @@
     },
     {
       "$id": "f950ab60-cf7f-45e5-af01-556e051a6915",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": "15d6487f-ada7-456b-a140-e753d39b318c",
@@ -25400,7 +25400,7 @@
     },
     {
       "$id": "69ecc2e9-9a05-4b75-b716-a9982dce71eb",
-      "length": 3,
+      "length": 5,
       "pluginMetadata": {
       },
       "symbol": "ea01b156-af2e-45ca-a8cb-be0c0b19b7e4",
@@ -25410,7 +25410,7 @@
     },
     {
       "$id": "e91b4266-1e32-4315-8173-11846adc95c9",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": "d9e46d04-44e5-45cd-8130-7f2c81579a56",
@@ -25430,7 +25430,7 @@
     },
     {
       "$id": "9ef08ca4-b56e-4753-8099-b9891904ec42",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": "d3c0c1f0-3d7d-48b7-affa-b30117562d66",
@@ -25440,7 +25440,7 @@
     },
     {
       "$id": "b73ca032-76db-48eb-931f-0713c3730314",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": "425d8c7d-ebb5-40bc-8c88-3001522a55ed",
@@ -25460,7 +25460,7 @@
     },
     {
       "$id": "b87dac2c-9d22-432b-8c82-c99b6ca975c3",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": "20cea14c-5a76-478a-92df-ecc570d331e8",
@@ -25470,7 +25470,7 @@
     },
     {
       "$id": "040a3c11-4e64-49d6-bb71-1a1bcfc32d50",
-      "length": 3,
+      "length": 5,
       "pluginMetadata": {
       },
       "symbol": "e55fcb73-2794-47f6-a86f-b23c31e7b773",
@@ -25480,7 +25480,7 @@
     },
     {
       "$id": "0cab44f5-9e83-4ef2-8268-ff81274e52ba",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": "1b6574d6-6377-4622-857b-2b95f8934916",
@@ -25500,7 +25500,7 @@
     },
     {
       "$id": "44aa2624-c403-457a-a2bb-541d2f9a1f2e",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25510,7 +25510,7 @@
     },
     {
       "$id": "60685481-684e-4ddf-b1fd-197e4d4693ce",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25530,7 +25530,7 @@
     },
     {
       "$id": "7ec05a03-f84c-4d18-9daa-7b9687136b68",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": "097cd89d-47bd-4ff7-b1ec-8ea6ac933d8d",
@@ -25540,7 +25540,7 @@
     },
     {
       "$id": "074276be-6935-458b-a481-cff53179b3aa",
-      "length": 3,
+      "length": 5,
       "pluginMetadata": {
       },
       "symbol": "46ff6d31-a1f9-4013-bc7a-f6d27350bed4",
@@ -25550,7 +25550,7 @@
     },
     {
       "$id": "3db2e29a-a9f7-4ed2-8c69-46385a94d999",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25570,7 +25570,7 @@
     },
     {
       "$id": "1eaa8e35-f457-414a-84f9-20e5cd526796",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25580,7 +25580,7 @@
     },
     {
       "$id": "3dd562b4-7df5-401f-b7c5-b9455b264088",
-      "length": 2,
+      "length": 3,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25600,7 +25600,7 @@
     },
     {
       "$id": "dd6e5694-c5eb-4e0d-88c3-4fd14acccdf7",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25610,7 +25610,7 @@
     },
     {
       "$id": "73a8359c-daf3-453d-b5eb-369ebcba874d",
-      "length": 3,
+      "length": 5,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -25620,7 +25620,7 @@
     },
     {
       "$id": "ffe26df8-9cd7-4754-b8ff-12728b3b0cd4",
-      "length": 5,
+      "length": 6,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -28646,7 +28646,7 @@
     },
     {
       "$id": "b94a2cec-7c90-41e3-a49d-d3a42fc6f384",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": "b0c57930-064d-4f3a-ad42-a337f4912b37",
@@ -28736,7 +28736,7 @@
     },
     {
       "$id": "e08c994a-a879-45d1-84e4-938110afd391",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": "04296c52-d10d-4fb2-9ab3-d4f9b44de480",
@@ -28746,7 +28746,7 @@
     },
     {
       "$id": "5caab329-bb18-4762-9249-bec07dfe50d9",
-      "length": 3,
+      "length": 5,
       "pluginMetadata": {
       },
       "symbol": "0bdad020-3d08-4669-969a-3bd4161ffff1",
@@ -28756,7 +28756,7 @@
     },
     {
       "$id": "155a6a8a-eb4b-46ea-a3ee-4b1a2ece3f67",
-      "length": 2,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": "01721212-d603-4138-8c73-a9e26ba894f3",
@@ -28766,7 +28766,7 @@
     },
     {
       "$id": "0c81ed73-c522-4646-a547-06943779588e",
-      "length": 2,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": "eaa2684c-6303-4564-ac97-e8ef92f9a215",
@@ -28776,7 +28776,7 @@
     },
     {
       "$id": "198c8ce4-d7cb-467f-986e-b9e70f9de490",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -28866,7 +28866,7 @@
     },
     {
       "$id": "e3bb0f20-9c15-4185-a4dd-0f1bdf51f09a",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -28876,7 +28876,7 @@
     },
     {
       "$id": "920d8d4c-3a47-49f2-8443-a34add41f96d",
-      "length": 3,
+      "length": 5,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -28886,7 +28886,7 @@
     },
     {
       "$id": "9b5f1410-54c1-46af-9bd1-5fbc616ce677",
-      "length": 2,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -28896,7 +28896,7 @@
     },
     {
       "$id": "c6d36f20-c298-4073-a451-80e1d7ba9ff4",
-      "length": 2,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -28906,7 +28906,7 @@
     },
     {
       "$id": "045957dd-e11f-4670-974d-25faf7dc564e",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": "cb870c8a-f265-4ddc-9411-641ccc6db4a3",
@@ -28965,16 +28965,6 @@
       "type": "COLLISION_BOX"
     },
     {
-      "$id": "8a6263b4-09e5-4dd3-8464-702087d360c7",
-      "length": 3,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
       "$id": "82faba7d-bf7c-4a51-8e2e-e1cbfe5332ce",
       "length": 4,
       "pluginMetadata": {
@@ -28996,7 +28986,7 @@
     },
     {
       "$id": "0b22d11b-de91-4a1a-a27e-b8d9761b9a78",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": "97c302f8-991e-4501-a407-1faf361c6243",
@@ -29006,7 +28996,7 @@
     },
     {
       "$id": "931daa49-e840-4ebc-a672-a414bfd0129e",
-      "length": 3,
+      "length": 5,
       "pluginMetadata": {
       },
       "symbol": "cf2cffc3-5eb7-4aff-b048-c635c23ebe84",
@@ -29016,7 +29006,7 @@
     },
     {
       "$id": "ef3c270f-d2ad-4c4a-bdc1-1d0a5411275d",
-      "length": 2,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": "1a90f5fb-7c97-492a-9346-301e8cb403e5",
@@ -29026,7 +29016,7 @@
     },
     {
       "$id": "f1bcc89a-57a0-4b45-91e2-164163df7a98",
-      "length": 2,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": "53761c35-74db-434f-a8ea-86aa297736ba",
@@ -29036,7 +29026,7 @@
     },
     {
       "$id": "026947ba-6a39-4bfd-aef7-dcbb007da272",
-      "length": 3,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -29075,16 +29065,6 @@
       "type": "COLLISION_BOX"
     },
     {
-      "$id": "c3546fec-8f74-4ca6-8dba-5411dd7081f9",
-      "length": 1,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
       "$id": "84c88e7c-213f-41ff-a77a-e143ee6c526a",
       "length": 1,
       "pluginMetadata": {
@@ -29095,48 +29075,8 @@
       "type": "COLLISION_BOX"
     },
     {
-      "$id": "0f409a57-39c7-49a5-a9c7-1b925a7325ac",
-      "length": 3,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "94de3d3a-bb1e-48bf-b2e2-d904edadd360",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "6e32f92e-ca79-48f4-ad98-c32ae4e75102",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "3261b179-177f-45c2-b9ae-1137f7e43acc",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "8bbb2467-402a-4bad-b1db-67baea982061",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "0728b313-12b8-46f6-8211-8b30863e5f38",
-      "length": 3,
-      "pluginMetadata": {
-      },
-      "symbol": "d20cccc2-efb5-40ed-b3fb-0626d2553b47",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
       "$id": "290c5a7b-7e48-428b-9b06-e5a131c7d62d",
-      "length": 3,
+      "length": 5,
       "pluginMetadata": {
       },
       "symbol": "3633cbb3-4026-4cc8-b1ec-bf5a8bab9581",
@@ -29146,7 +29086,7 @@
     },
     {
       "$id": "c665d220-4a63-4d30-bc26-7942812369c6",
-      "length": 2,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": "bf2035fc-0e09-4ec2-9af7-2592c7d6fb12",
@@ -29156,7 +29096,7 @@
     },
     {
       "$id": "6e3f16b3-ec69-4b09-81bb-675e7e063e78",
-      "length": 2,
+      "length": 4,
       "pluginMetadata": {
       },
       "symbol": "6506c649-d91d-4e60-8391-ebe1fddeb171",
@@ -29167,7 +29107,7 @@
     {
       "$id": "573e6801-1fd3-41b6-b2a8-cb0626883a08",
       "code": "",
-      "length": 8,
+      "length": 9,
       "pluginMetadata": {
       },
       "type": "FRAME_SCRIPT"
@@ -29175,7 +29115,7 @@
     {
       "$id": "86aeaf18-5079-45fa-a29c-38c7ad532628",
       "code": "self.reactivateHitboxes();\r\nself.updateHitboxStats(0, {damage: 12, knockbackGrowth: 70, baseKnockback: 75, hitstop: -1, selfHitstop: -1, angle: 80});",
-      "length": 1,
+      "length": 30,
       "pluginMetadata": {
       },
       "type": "FRAME_SCRIPT"
@@ -36205,7 +36145,7 @@
     {
       "$id": "b7d16703-08f6-4b21-9413-3ae223be9708",
       "code": "",
-      "length": 4,
+      "length": 5,
       "pluginMetadata": {
       },
       "type": "FRAME_SCRIPT"
@@ -36213,7 +36153,7 @@
     {
       "$id": "1d00c55e-1962-4f90-9ebd-fdf9252cd44d",
       "code": "AudioClip.play(self.getResource().getContent(\"slap\"));",
-      "length": 1,
+      "length": 28,
       "pluginMetadata": {
       },
       "type": "FRAME_SCRIPT"
@@ -36820,6 +36760,66 @@
       "pluginMetadata": {
       },
       "symbol": "78625afc-9957-4809-b495-1ac4b74d54f1",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "16b1a738-f5ee-4a0c-92cb-229eee1742e2",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "690d0c37-09cf-4cdb-a03d-a2e2eee09b49",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "92b3119b-0d9e-4974-bcc5-8107c78e752c",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "95c36546-4521-4cc2-90c5-5ec518b020b2",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "19a5049b-252b-42b7-abc3-4dc941291354",
+      "length": 1,
+      "pluginMetadata": {
+      },
+      "symbol": "ab17d3b8-683e-4940-9b67-14c2fbdaca6f",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "66f14798-1964-420d-8d42-d0f76689bb6a",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "dc7caecc-95c0-4c46-9403-9ba714369b6e",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "e03661e4-e2c2-4a51-a7bc-21ab39728c6a",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "f6562f72-8454-4bc4-aec9-6a0a45f26827",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "cb81e7a2-8556-4ead-9cdf-1403567de153",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "94dc912e-5f3e-4184-9d5a-aabb8281ece3",
       "tweenType": "LINEAR",
       "tweened": false,
       "type": "COLLISION_BOX"
@@ -47934,7 +47934,7 @@
         "771e71d2-d22b-4299-ada9-13a8a88c8110",
         "31065f06-65a4-46ef-92f6-16b51abecfad",
         "ddca2ca3-7070-4faf-8e5d-1414694f078d",
-        "8a6263b4-09e5-4dd3-8464-702087d360c7",
+        "16b1a738-f5ee-4a0c-92cb-229eee1742e2",
         "82faba7d-bf7c-4a51-8e2e-e1cbfe5332ce",
         "fdf1e161-e473-4a9b-b9c2-ffb06a8417c5",
         "0b22d11b-de91-4a1a-a27e-b8d9761b9a78",
@@ -47962,12 +47962,12 @@
         "d724c348-5003-4a45-bfa4-891f83cc6caa",
         "2a81387d-15d7-461e-8102-6af41bc4c56d",
         "6d049014-dbd4-407c-a6ac-1178df9912ef",
-        "c3546fec-8f74-4ca6-8dba-5411dd7081f9",
+        "19a5049b-252b-42b7-abc3-4dc941291354",
         "84c88e7c-213f-41ff-a77a-e143ee6c526a",
-        "0f409a57-39c7-49a5-a9c7-1b925a7325ac",
-        "94de3d3a-bb1e-48bf-b2e2-d904edadd360",
-        "3261b179-177f-45c2-b9ae-1137f7e43acc",
-        "0728b313-12b8-46f6-8211-8b30863e5f38",
+        "92b3119b-0d9e-4974-bcc5-8107c78e752c",
+        "66f14798-1964-420d-8d42-d0f76689bb6a",
+        "e03661e4-e2c2-4a51-a7bc-21ab39728c6a",
+        "cb81e7a2-8556-4ead-9cdf-1403567de153",
         "290c5a7b-7e48-428b-9b06-e5a131c7d62d",
         "c665d220-4a63-4d30-bc26-7942812369c6",
         "6e3f16b3-ec69-4b09-81bb-675e7e063e78"
@@ -77223,11 +77223,11 @@
       "pluginMetadata": {
       },
       "rotation": 0,
-      "scaleX": 22,
-      "scaleY": 15,
+      "scaleX": 24,
+      "scaleY": 26,
       "type": "COLLISION_BOX",
       "x": 18,
-      "y": -25
+      "y": -33
     },
     {
       "$id": "658e5fb1-cecd-4f15-8f3a-292c1fe5db58",
@@ -77238,11 +77238,11 @@
       "pluginMetadata": {
       },
       "rotation": 0,
-      "scaleX": 18,
-      "scaleY": 13,
+      "scaleX": 23,
+      "scaleY": 18,
       "type": "COLLISION_BOX",
       "x": 40,
-      "y": -17
+      "y": -20
     },
     {
       "$id": "fe3f56dd-f69f-44f4-97c8-239d704396c0",
@@ -77253,8 +77253,8 @@
       "pluginMetadata": {
       },
       "rotation": 0,
-      "scaleX": 18,
-      "scaleY": 11,
+      "scaleX": 25,
+      "scaleY": 14,
       "type": "COLLISION_BOX",
       "x": 58,
       "y": -10
@@ -81359,11 +81359,11 @@
       "pluginMetadata": {
       },
       "rotation": 0,
-      "scaleX": 21,
-      "scaleY": 20,
+      "scaleX": 24,
+      "scaleY": 25,
       "type": "COLLISION_BOX",
       "x": 22,
-      "y": -58
+      "y": -60
     },
     {
       "$id": "05f11403-4ca0-45bc-a6e6-193d5d520c1a",
@@ -81634,51 +81634,6 @@
       "type": "COLLISION_BOX",
       "x": 30,
       "y": -131
-    },
-    {
-      "$id": "6e32f92e-ca79-48f4-ad98-c32ae4e75102",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 11,
-      "scaleY": 17,
-      "type": "COLLISION_BOX",
-      "x": 27,
-      "y": -110
-    },
-    {
-      "$id": "8bbb2467-402a-4bad-b1db-67baea982061",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 11,
-      "scaleY": 17,
-      "type": "COLLISION_BOX",
-      "x": 27,
-      "y": -110
-    },
-    {
-      "$id": "d20cccc2-efb5-40ed-b3fb-0626d2553b47",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 11,
-      "scaleY": 17,
-      "type": "COLLISION_BOX",
-      "x": 27,
-      "y": -110
     },
     {
       "$id": "3633cbb3-4026-4cc8-b1ec-bf5a8bab9581",
@@ -90115,6 +90070,96 @@
       "type": "COLLISION_BOX",
       "x": 9,
       "y": -90
+    },
+    {
+      "$id": "690d0c37-09cf-4cdb-a03d-a2e2eee09b49",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 31,
+      "scaleY": 96,
+      "type": "COLLISION_BOX",
+      "x": 1,
+      "y": -96
+    },
+    {
+      "$id": "95c36546-4521-4cc2-90c5-5ec518b020b2",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 38,
+      "type": "COLLISION_BOX",
+      "x": 30,
+      "y": -131
+    },
+    {
+      "$id": "ab17d3b8-683e-4940-9b67-14c2fbdaca6f",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 38,
+      "type": "COLLISION_BOX",
+      "x": 30,
+      "y": -131
+    },
+    {
+      "$id": "dc7caecc-95c0-4c46-9403-9ba714369b6e",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 38,
+      "type": "COLLISION_BOX",
+      "x": 30,
+      "y": -131
+    },
+    {
+      "$id": "f6562f72-8454-4bc4-aec9-6a0a45f26827",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 38,
+      "type": "COLLISION_BOX",
+      "x": 30,
+      "y": -131
+    },
+    {
+      "$id": "94dc912e-5f3e-4184-9d5a-aabb8281ece3",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 38,
+      "type": "COLLISION_BOX",
+      "x": 30,
+      "y": -131
     }
   ],
   "tags": [

--- a/Kung Fu Man/library/scripts/Character/HitboxStats.hx
+++ b/Kung Fu Man/library/scripts/Character/HitboxStats.hx
@@ -31,16 +31,16 @@
 
 	//STRONG ATTACKS
 	strong_forward_attack: {
-		hitbox0: {damage: 8, angle: 40, baseKnockback: 55, knockbackGrowth: 45, hitstop: -1, selfHitstop:-1, limb:AttackLimb.FOOT},
-		hitbox1: {damage: 12, angle: 40, baseKnockback: 70, knockbackGrowth: 55, hitstop: -1, selfHitstop:-1, limb:AttackLimb.FOOT}
+		hitbox0: {damage: 13, angle: 40, baseKnockback: 50, knockbackGrowth: 70, hitstop:-1, hitstopOffset:6, selfHitstop:-1, selfHitstopOffset:6, limb:AttackLimb.FOOT},
+		hitbox1: {damage: 13, angle: 40, baseKnockback: 50, knockbackGrowth: 70, hitstop:-1, hitstopOffset:6, selfHitstop:-1, selfHitstopOffset:6, limb:AttackLimb.FOOT}
 	},
 	strong_up_attack: {
-		hitbox0: {damage: 3, knockbackGrowth: 0, baseKnockback: 50, hitstop: -1, selfHitstop: -1, hitstun: -1, reversibleAngle: false, angle: 85, limb:AttackLimb.FIST}
+		hitbox0: {damage: 3, knockbackGrowth: 0, baseKnockback: 50, hitstop:-1, hitstopOffset:2, selfHitstop:-1, selfHitstopOffset:2, reversibleAngle: false, directionInfluence: false, angle: 85, limb:AttackLimb.FIST}
 	}, 
 	strong_down_attack: {
-		hitbox0: {damage: 8, angle: 70, baseKnockback: 60, knockbackGrowth: 55, hitstop: -1, selfHitstop:-1, limb:AttackLimb.BODY},
-		hitbox1: {damage: 10, angle: 70, baseKnockback: 60, knockbackGrowth: 55, hitstop: -1, selfHitstop:-1, limb:AttackLimb.BODY},
-		hitbox2: {damage: 12, angle: 70, baseKnockback: 60, knockbackGrowth: 55, hitstop: -1, selfHitstop:-1, limb:AttackLimb.BODY}
+		hitbox0: {damage: 10, angle: 35, baseKnockback: 55, knockbackGrowth: 65, hitstop:-1, hitstopOffset:6, selfHitstop:-1, selfHitstopOffset:6, limb:AttackLimb.BODY},
+		hitbox1: {damage: 10, angle: 35, baseKnockback: 55, knockbackGrowth: 65, hitstop:-1, hitstopOffset:6, selfHitstop:-1, selfHitstopOffset:6, limb:AttackLimb.BODY},
+		hitbox2: {damage: 12, angle: 35, baseKnockback: 60, knockbackGrowth: 70, hitstop:-1, hitstopOffset:8, selfHitstop:-1, selfHitstopOffset:8, limb:AttackLimb.BODY}
 	},
 
 	//AERIAL ATTACKS


### PR DESCRIPTION
### Summary
Updated all of Kung Fu Mans strong attacks to be more fair, have worse frame data with more recovery, do more damage and knockback and applied hitstopOffset to feel more impactful when landed.

### Changes
- strong_up_attack was largely untouched except for hitstopOffset.
- strong_forward_attack got more damage and knockback as it was previously very weak.
- strong_down_attack also received more damage and knockback as well as an improved angle for killing/setting up edgeguards when used at the ledge.

### Animations Changed
- strong_up_attack
- strong_forward_attack
- strong_down_attack