### PR TITLE
Update special_down

### DIFF
--- a/Kung Fu Man/library/entities/character.entity
+++ b/Kung Fu Man/library/entities/character.entity
@@ -1401,6 +1401,108 @@
       }
     },
     {
+      "$id": "1773bbbf-f688-4450-8f67-7ebaed5d72da",
+      "layers": [
+        "51170727-2c13-40b6-b831-0d365c151c4f",
+        "ed1948ec-d1be-4bdf-afb8-63698277e9b9",
+        "b37215e8-5f9f-462f-a344-4992d3b6f487",
+        "7cc43a3f-e80a-4c6b-9aea-5fcf64318409",
+        "a416930c-33aa-4e5e-8f16-868759713ac0",
+        "13d647f9-0475-4b5a-98a0-3c6d2ff28139"
+      ],
+      "name": "special_down_loop",
+      "pluginMetadata": {
+      }
+    },
+    {
+      "$id": "0ada98a1-efc7-4834-8b89-f7deec7f3558",
+      "layers": [
+        "12a81570-be69-4c26-bfac-85fa2f1b8bfa",
+        "700dbf6a-611e-4611-9a94-8ee95f76c74e",
+        "19dce852-ed02-41d4-a983-ee62fb04ed03",
+        "bbb50dec-76a3-405b-b24e-239deee4e8d7",
+        "db0a943f-f9bd-4e92-ab2c-c2f4190217c7",
+        "677a7f6c-88a0-4428-849f-a7dd1f6ba63c"
+      ],
+      "name": "special_down_air_loop",
+      "pluginMetadata": {
+      }
+    },
+    {
+      "$id": "c58edc98-9b3e-4f45-9c20-8128522d2a2f",
+      "layers": [
+        "611c51bb-0ec0-4f69-9868-e3ac592401f5",
+        "af8cce5e-b5d3-4476-bc90-bc035f46520f",
+        "d5948371-752f-4936-abe9-30107e7b70b1",
+        "cb611241-3019-4951-9af3-99a0eb90f4fc",
+        "d0a165d5-efb5-4314-9f86-08569eb59f20",
+        "90e69ba8-a956-496d-b4d4-581731198653",
+        "fdb2e8e4-7729-4e68-8841-b9998a0292c5",
+        "9cf86571-8172-4e9d-8aac-f784aebbe20a"
+      ],
+      "name": "special_down_attack",
+      "pluginMetadata": {
+      }
+    },
+    {
+      "$id": "5c89b249-8412-43d4-be80-4ba2236bc9ae",
+      "layers": [
+        "ebdb84b0-bd57-420a-9689-8a03bb2f6ccf",
+        "36b7c953-dc25-4da0-8de5-d4158aed5508",
+        "6588895b-71a0-42f1-8687-5c6da0599d44",
+        "7aed755e-4c90-44b1-91dc-e2fa4dfc0ab6",
+        "662b184f-58ed-4b9c-9b31-a03d896b012f",
+        "48f2b8c6-a0d7-4e1b-85aa-a5338c549ef9",
+        "f1480963-268f-4ed2-a753-952f01153847",
+        "e51f5f31-53b3-41e7-a4bb-54ca045e8c96"
+      ],
+      "name": "special_down_air_attack",
+      "pluginMetadata": {
+      }
+    },
+    {
+      "$id": "4da7ce1c-462a-449b-bb32-0b15c3f5cc4e",
+      "layers": [
+        "35432f90-c09f-43ce-b894-9f826db7f48f",
+        "2bd1f54d-5bbd-4b94-af26-2f461507d4f1",
+        "c6804fff-1814-4db5-9594-12935f8609e8",
+        "20079a30-64cf-43a4-a2f6-fedbb329006b",
+        "030aa8ba-0e6c-4ff4-b4e4-77317627fd44",
+        "3d614683-4892-4675-bb02-bb2bdd2fa2a4"
+      ],
+      "name": "special_down_clutch_attack",
+      "pluginMetadata": {
+      }
+    },
+    {
+      "$id": "e68cf455-159d-4023-8297-b584c38efd07",
+      "layers": [
+        "dc5039d6-d97b-4686-9965-e0b9518e13cf",
+        "639d968e-1602-4471-ae1c-2836796c9bc2",
+        "39bdfbed-b97d-466f-a85b-b6ba7d77ccc4",
+        "1d0c358c-a271-4f8a-b1eb-2dd20bb12576",
+        "601c6a92-7d15-4c9f-b903-9c862ea0e194",
+        "db326a84-763b-4581-beb8-0bebc016d747"
+      ],
+      "name": "special_down (copy)",
+      "pluginMetadata": {
+      }
+    },
+    {
+      "$id": "f2847a0e-166a-49cf-9f83-b72b7a3d76eb",
+      "layers": [
+        "d931a31c-260f-4eef-a5bf-8dbd88d8bad9",
+        "40251165-5b6d-446b-beb1-9c696bba575e",
+        "7fa6145f-d40f-4b2b-941f-1588d4b7c81b",
+        "b030b373-77a2-4685-9af5-0e1b77e3111c",
+        "56235a67-0692-4186-a04f-d4e4c7138bc6",
+        "e5e066e3-704a-4810-a0ea-6af1e2cd9ee8"
+      ],
+      "name": "special_down_air (copy)",
+      "pluginMetadata": {
+      }
+    },
+    {
       "$id": "8524261e-f0ff-4111-8f32-32feb31c8848",
       "layers": [
         "8aa98ba0-62ad-4cba-92e7-5f8305979ae4",
@@ -15080,456 +15182,6 @@
       "type": "COLLISION_BOX"
     },
     {
-      "$id": "a88e3fac-a2bd-4521-88fd-5f795e76248a",
-      "length": 3,
-      "pluginMetadata": {
-      },
-      "symbol": "07c898a1-e4fe-4204-a8ab-8df46c378e93",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "1ada0ba1-7737-4fd9-98ab-97bef5c4d220",
-      "length": 3,
-      "pluginMetadata": {
-      },
-      "symbol": "7c45c3b1-a464-4864-bd9e-fd568717a4b5",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "67520320-8f94-47b5-b2c2-363f8d4bef90",
-      "length": 3,
-      "pluginMetadata": {
-      },
-      "symbol": "6db07d7a-42ce-42b3-8574-453f19e3f6c1",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "8820ca38-56e6-43b3-9783-f3340842a9c7",
-      "length": 3,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "5a0d3685-8042-4c52-aaf4-c4fd0248183a",
-      "length": 3,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "13ed764a-8bfb-4d55-8c5c-eac762d186a6",
-      "length": 7,
-      "pluginMetadata": {
-      },
-      "symbol": "d808bf7b-c577-4f54-8f83-6eac7a9dbe25",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "8454cfc8-43b2-4f68-8dd4-4c7bf1810407",
-      "length": 7,
-      "pluginMetadata": {
-      },
-      "symbol": "8514e7c1-c8ab-4198-91d5-95cb307e2fe0",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "8a749202-9dac-4f53-a47b-7f4fca5a2bbd",
-      "length": 7,
-      "pluginMetadata": {
-      },
-      "symbol": "241b3a1f-d30d-4f66-8df4-514bc6065f48",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "3ffe2826-a62b-4443-8702-e46987eddf22",
-      "length": 7,
-      "pluginMetadata": {
-      },
-      "symbol": "b0272e15-4b0c-4e68-9a6e-3acbbc69c0ea",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "438e1b51-ac1f-4e61-af56-211a71a7214c",
-      "length": 7,
-      "pluginMetadata": {
-      },
-      "symbol": "f76166bf-7ad4-48c0-a15a-8ac1bb9a46c8",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "166b31a1-4533-4cc5-a90e-80a85fae865d",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "1020dbf5-d87c-4cd0-874b-495086b36a36",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "56b153f1-8b49-427b-b272-491b29bddae7",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "142bf58b-48e2-4568-92a4-f17a5b4d784a",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "287b925c-3ecd-41b5-ab71-3b0a5f50227d",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "cb758834-3b02-49a2-9a73-8e1c9e625854",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "82d9fe96-e00a-4bf1-8be9-1ebf3d20d93f",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "eaa97071-c6a8-4717-b413-05ed20c7fe2b",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "221752d4-0241-45e0-b405-684b1265287d",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "4fd4cd36-244b-4e79-9d5b-e9e66a13d04b",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "b9519095-e1db-4b9a-99cd-fba2d7b43ac0",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "efd3a5f5-c1ea-4649-b3ca-66703676a3fa",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "40dd4651-4b1b-4748-9d9b-c0a0153d678a",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "6cc9a940-1201-4187-a5bc-6fe343d9c8e5",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "8249a758-b441-4b14-a5a4-6837a9cb4553",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "2c78bca4-ce3d-44c9-b9e1-e841bf4d355b",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "6b9b5427-261a-4b99-a689-7b9cc5ed377d",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "37aa0b13-3e2a-4d3d-9de1-2c2ea9758a52",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "44297bd2-72d4-4d5c-a92c-f17e1513136d",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "c21e1713-8e8f-42b3-baa2-4356b0c9754c",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "121b5a0f-9e35-4039-8e7a-82d240de444e",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "b0e5a82f-9cf6-4cbf-bd3f-a0ee73487aae",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "e16fdb40-d141-4208-b804-df02ab61d2c4",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "558391a3-2d3b-48d7-8256-aa840e552541",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "2c2e816b-5d1c-448d-86d4-14a24da7f19a",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "c324607e-6267-49c2-b829-0e69c337ca0c",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "8ee75c68-45e4-439f-ab50-fd3c4a37eac1",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "9d0f1e23-1216-46fa-adb6-5e4443b764aa",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "773065b8-0248-4a33-9d90-14e06f09a427",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "b9105367-1796-42cb-97f0-069660954d8c",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "55414dc0-0f0d-44e9-80cc-5d22aa2dfcdf",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "f92d603a-82f5-4733-8083-ec3771c7a055",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "f43b221d-65a4-41c4-a2e0-47480e2fa81e",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "6d9f79c3-16d4-4f8f-a61f-0d9baa3bede7",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "3aa208b0-d3af-4b4c-9e52-ea531e6dcc5c",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "227ba522-2fe6-4f2e-a937-6d60e964c975",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "d2e6b53d-d48a-428b-822f-b5acaaa27ae0",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "77db312c-8287-4827-ab00-be5d6e7e75d4",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "16870f16-ab60-4640-abd7-ac1cb5860f62",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "7d99ecdc-fa6f-409b-8161-9cda38d75ae8",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "d680ad6b-c7df-4450-a8f5-3fa664a5bb22",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "ca07f7ce-3bfe-46b5-845b-b35bb99a3a96",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "d3007015-60bc-4d4e-8863-3ffed11b0993",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "b7da70e4-f941-44f3-bd62-f26d867c225a",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "67267041-2091-41f6-858b-880ccb5e7cfa",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "aeb9a001-cf66-440b-b607-4a2d8ee0d380",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "94d38728-69ee-4496-8cc1-39d66b2062b2",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "b7edc1d5-f9cb-4e90-a98e-bf3460a580b5",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "96288ec5-22da-4823-ab39-d34ddf4198f5",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "8bff24d3-c407-4354-a2bd-48fa2f412fe9",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "2614fd93-8d75-4cd4-bfee-04ab7ed7baaa",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "76ac3877-4e9f-4057-9781-d8331fae2d41",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "3937d578-c87f-4f24-bc42-cead0b498bf0",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "c43b13e2-746a-4bd7-91da-21458fe93c87",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "635050f9-bdcd-4e88-97ea-0c49edc0310a",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "7071d38b-b8fd-4ff5-96c8-97b37ea0f899",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "e9cdff04-4476-44ab-9014-ae92c25d312c",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
       "$id": "f5736930-f47b-4d6f-a88f-ac9be43dd085",
       "length": 2,
       "pluginMetadata": {
@@ -24194,31 +23846,7 @@
     {
       "$id": "3a2d5df4-67a3-49ec-9fdb-a5c07d74928a",
       "code": "",
-      "length": 8,
-      "pluginMetadata": {
-      },
-      "type": "FRAME_SCRIPT"
-    },
-    {
-      "$id": "f4e359e2-63ae-4428-9956-fff75e235520",
-      "code": "self.setXSpeed(18);",
-      "length": 7,
-      "pluginMetadata": {
-      },
-      "type": "FRAME_SCRIPT"
-    },
-    {
-      "$id": "6c47d820-90cd-4c8e-b390-b063fc4061fb",
-      "code": "self.reactivateHitboxes();\r\nself.updateHitboxStats(0, {damage: 8, knockbackGrowth: 45, baseKnockback: 75, hitstop: -1, selfHitstop: -1, angle: 60, reversibleAngle: false});\r\n\r\nAudioClip.play(self.getResource().getContent('special_down'));",
-      "length": 2,
-      "pluginMetadata": {
-      },
-      "type": "FRAME_SCRIPT"
-    },
-    {
-      "$id": "92bdcf63-b5a8-40a5-9152-361cca411cb8",
-      "code": "self.resetMomentum();",
-      "length": 1,
+      "length": 5,
       "pluginMetadata": {
       },
       "type": "FRAME_SCRIPT"
@@ -29218,123 +28846,9 @@
       "type": "IMAGE"
     },
     {
-      "$id": "0f5e9d0c-50d0-44ca-b06a-8c130d97e4b6",
-      "length": 3,
-      "pluginMetadata": {
-      },
-      "symbol": "ed2886b2-3d5e-4004-a3c2-29d257fea00d",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "0ba3961a-74d3-4fe2-9ef8-d498831f8e34",
-      "length": 7,
-      "pluginMetadata": {
-      },
-      "symbol": "63123f2b-762a-467d-a3df-b02efb3e759e",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "bd4f356c-caaf-4c5f-a7ec-ebd3f7ca10c3",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "67a501ef-4c1e-4678-a1fd-0645998f7ef7",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "57784474-0d51-475b-b27c-81fe3174297d",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "6ba7c10f-86a5-44d7-bc2d-2ea9268f88b3",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "254062cb-fc1d-42df-bceb-4ed0c0f8712e",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "0ac18ada-581c-45ac-9e35-6fa564060f14",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "c73440a5-59ca-47e5-907e-6c253de44035",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "16b64a6e-a960-420e-99c4-6c039a16f20e",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "68b19214-89fa-4eb0-886c-a5987bfb5acd",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "43614c1a-e86a-4faf-ae06-29a56a6f0839",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "244f0a85-d40e-419a-9bda-069a1c7dae7a",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "9c720538-31d9-4cf2-8d04-1dcaed71dae8",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
-      "$id": "e60d3c19-d931-4992-9cc5-fe4450476315",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "57105572-810f-45bf-9595-9757a4c05184",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "IMAGE"
-    },
-    {
       "$id": "d4e80419-9d31-49cd-b983-d1535a0bc6b8",
       "code": "self.addTimer(1,36,function() {\r\n    self.setYVelocity(0);\r\n});",
-      "length": 8,
-      "pluginMetadata": {
-      },
-      "type": "FRAME_SCRIPT"
-    },
-    {
-      "$id": "eaf74e2d-bbc7-439e-ad12-3aec18696b35",
-      "code": "self.setXSpeed(18);",
-      "length": 7,
-      "pluginMetadata": {
-      },
-      "type": "FRAME_SCRIPT"
-    },
-    {
-      "$id": "57735e9f-2621-4374-aeea-498be8de11cc",
-      "code": "self.reactivateHitboxes();\r\nself.updateHitboxStats(0, {damage: 8, knockbackGrowth: 45, baseKnockback: 75, hitstop: -1, selfHitstop: -1, angle: 60, reversibleAngle: false});\r\nAudioClip.play(self.getResource().getContent('special_down'));\r\n",
-      "length": 2,
-      "pluginMetadata": {
-      },
-      "type": "FRAME_SCRIPT"
-    },
-    {
-      "$id": "cef02b68-9f2c-4e7a-a828-6401371e3a3a",
-      "code": "self.resetMomentum();",
-      "length": 1,
+      "length": 5,
       "pluginMetadata": {
       },
       "type": "FRAME_SCRIPT"
@@ -29342,96 +28856,6 @@
     {
       "$id": "7a3f657b-a85a-4b92-9b08-3813d04aa885",
       "length": 5,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "8ab113ff-401a-4fde-9aff-0798496bf196",
-      "length": 3,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "9357e1b7-0630-4d0b-8e81-408a562f8dd2",
-      "length": 7,
-      "pluginMetadata": {
-      },
-      "symbol": "c51daa98-6a08-4053-ac0a-f8fd35be1fcd",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "a3236be9-4afb-4cd8-9922-57270cef1cf2",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "c0c8bdc4-1be6-416e-9bf0-af3fed18b8c0",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "f8d08be8-dfb8-4fb0-b55c-cecdcefb555d",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "5b837ad7-516c-49ac-83ea-64a312cb6e31",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "785de533-462f-420a-9585-9b79d5b7d23e",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "c8a46a7f-c8bf-4665-add9-3b26229f34ef",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "2dd78b43-db14-4725-906c-89a7ee1ad74d",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "81b0d7ff-ff0b-4f49-a7a5-0020019e242d",
-      "length": 4,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -29450,96 +28874,6 @@
       "type": "COLLISION_BOX"
     },
     {
-      "$id": "754b8add-1fa6-49cc-b6f0-989a52d06485",
-      "length": 3,
-      "pluginMetadata": {
-      },
-      "symbol": "3bcef01a-f4dd-4310-a529-0be9b0b0e251",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "9ae5da2a-fc2c-41e2-bff2-d54e54efbaeb",
-      "length": 7,
-      "pluginMetadata": {
-      },
-      "symbol": "301d8c79-3418-4ec6-a316-f2eb6beb50d3",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "b13911e5-d201-404b-b231-f075ff1d62b8",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "ddcc30bf-809d-4c1b-abec-a94ff0c63ab2",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "79b31dd4-dc68-46d7-8fc8-0f8dda73b2d2",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "eb202f6c-9a7e-4540-ab4a-cde08c124906",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "758940d9-ad2d-4a48-b050-56757c24da27",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "fb17e06a-f88f-4e02-b6f9-1c057440931b",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "d85ca943-df40-458c-b230-29213fc666d9",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "97d6bd58-5067-45d6-ad95-8f0add8fe41a",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "44b5971a-9167-4e4c-9b3b-309b16c8f345",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "0c8ac6f0-d8be-4115-8709-042efa75752c",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "e6b1d823-a395-47bf-86a5-58af668acabc",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "709e2ea7-946b-44c3-9a80-9e6fc0adf4ec",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "28391c21-6048-4f32-9cda-7eb9add6b4d2",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "a10017d6-34d5-42ef-b9c2-11861986d025",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
       "$id": "afd77ddc-abba-4b45-b81f-1764bd32bef8",
       "length": 5,
       "pluginMetadata": {
@@ -29550,188 +28884,8 @@
       "type": "COLLISION_BOX"
     },
     {
-      "$id": "8d85c24e-f36c-43a1-be32-74d2dc2185f3",
-      "length": 3,
-      "pluginMetadata": {
-      },
-      "symbol": "ae2fa9e5-6cd2-41fa-8bf3-b7506a53d122",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "a22877fa-21b2-4f60-a1c3-c3c6d837c791",
-      "length": 7,
-      "pluginMetadata": {
-      },
-      "symbol": "9d367251-7b5a-44a1-9c33-325136f22d60",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "06f81d57-24fb-42c6-8c38-a9361b57b579",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "9d8c09f2-8697-417f-ab46-ebf5447ebd50",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "e1749500-243f-4ab0-89bf-05847810550a",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "8919506c-48b5-47aa-b827-be96ae1fc7d8",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "f9634689-41f0-4fca-a5e2-05e7c4789f48",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "a4859db1-3762-4a35-a60b-40e24b5c3301",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "49a234aa-38c7-4682-8359-3fd601785ce9",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "f062492a-e293-4b0f-bcbe-b66f906d5ca1",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "fb851bc5-347a-495f-8036-e531f028b3f9",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "3f90a932-f108-464b-95d3-132353187c9a",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "2c299c9b-19b8-45b4-99b6-58aaef26f630",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "73165140-c3a7-4b5f-9631-9d3f11ffb11f",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "79479f22-67b0-4f5d-83ea-5dd8dfe7f0d5",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": "67b23f82-813d-47ee-a50b-dde9827a2fe5",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
       "$id": "c3e3e4b0-daee-4991-983e-88021c83ae3d",
       "length": 5,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "c140f969-5ddd-4acb-8e6d-b42406f90030",
-      "length": 3,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "c09f6988-8985-49f4-b40a-c76259d662aa",
-      "length": 7,
-      "pluginMetadata": {
-      },
-      "symbol": "d90ad6ec-b778-40ae-ad66-6037e916649e",
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "2434eb3e-7f64-4454-9d9e-d2d06c1b1ba4",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "849f62dc-da7d-400d-a297-dad05e0872a6",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "e192b6fe-8deb-429e-a8e1-d5d870ed6e1c",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "580a663e-446f-4104-8de0-29dcce700242",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "020cda66-69d9-4d2d-a8c1-cdaf032c69c6",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "c0328e22-898a-4bce-9a53-a086a070cc13",
-      "length": 4,
-      "pluginMetadata": {
-      },
-      "symbol": null,
-      "tweenType": "LINEAR",
-      "tweened": false,
-      "type": "COLLISION_BOX"
-    },
-    {
-      "$id": "f4f5dde9-aa19-420f-8872-a82afade0c79",
-      "length": 4,
       "pluginMetadata": {
       },
       "symbol": null,
@@ -36916,6 +36070,2760 @@
       "tweenType": "LINEAR",
       "tweened": false,
       "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "42f73af2-b426-459d-b218-fcf3d85ca708",
+      "length": 2,
+      "pluginMetadata": {
+      },
+      "symbol": "7ddfbce4-8bc2-4271-a459-bda2c4bd99a0",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "ee2869c0-7371-4c1e-b679-b182c8333ebd",
+      "code": null,
+      "length": 1,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "2877890b-dd10-4a23-bb6f-21485ad629a4",
+      "length": 1,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "acc44348-d839-46be-aaa4-6e4464a9d523",
+      "length": 2,
+      "pluginMetadata": {
+      },
+      "symbol": "75fdebe7-114d-49e0-9a12-7f3edbe8d456",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "d1175980-7a44-4b1a-8e09-915173a5de95",
+      "length": 2,
+      "pluginMetadata": {
+      },
+      "symbol": "84680f8b-cac5-40e7-8c1f-32d7b46ba33b",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "6b5ebebb-c481-4e9f-8862-7ef4792589da",
+      "length": 1,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "79b53f82-9551-4578-8ecb-a5c3bef9adf5",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "6218077b-21d7-4243-be7c-cf2dfd618887",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "1969b03f-f920-4114-8ab2-982aa1c24433",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "d3493676-667a-4924-a10b-129ae92637c4",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "226b813d-a19a-41d5-ab40-e33559c7ea0c",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "ede556c2-1e47-4695-8610-8f573326c628",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "126cb4fa-598e-4dd2-a6d5-e6e00ec52669",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "3e62f543-3968-42ef-83b5-75166acdd228",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "648232f9-52d8-4c61-b981-c901706367ed",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "ab8b9cf0-3d1e-45ec-83f1-4b636cea0bd0",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "5ff01680-22a8-46e6-9ab0-bca73a40cd4d",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "769d9bd6-579f-459e-9112-e33ef7876c0d",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "e751ac80-8786-4d6e-8ac7-ad6bc73d41d0",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "e1abf7a7-7340-4678-9998-993bc37d360b",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "f754edc8-be2f-4315-8500-f986776090c7",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": "4931cfbf-38f9-4c08-ab2c-fdcb6fb0c182",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "33c4cb32-3242-4331-9bf1-9991e937096d",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "3c975ce0-7a5b-4d30-8756-29eb618ba3a9",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "0d025045-faca-44d3-85b6-578ed94acc9a",
+      "code": null,
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "12dee63b-a78f-4626-b4d1-71a536815a78",
+      "code": "self.setXSpeed(18*(1+self.getAnimationStat(\"storedChargePercent\")));",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "db7f3f23-1833-472f-8c29-6b49e0049ceb",
+      "code": "self.resetMomentum();\r\nAudioClip.play(self.getResource().getContent('special_down'));",
+      "length": 37,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "04f3f2ef-7b28-4466-8dab-3af200376385",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "54655408-eb24-410c-82c7-bf8cbda75638",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "0b73155f-2b4c-4155-bf85-8369d915b607",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "1e41ac38-2c81-4e17-acd7-c5aeb6be29c3",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "49c0122f-aaf2-4b6c-bd47-8f1f277ebe5e",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "9e9f30ce-f0ee-458b-8e91-9aa224a19cc7",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "c99ca1b1-54b1-40f0-9497-a28c883b14d4",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "ab411148-0245-4343-9434-f5fe473dd218",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "d2e6ec70-4bd9-4f90-9c77-53b6bf0a3900",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "c3ec950d-1c27-403c-a8eb-fbd5af68b9bf",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "3d244181-337f-4785-b6ba-8c35d9b9dfc3",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "e3375b77-dd8a-4f1d-a46c-e31750a4bf13",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "d9ae9670-0780-4c1d-849b-b802e75040ff",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "a704e43f-7c64-45b5-86fd-18d308ddffd9",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "f75cc14d-353a-4b6e-ac4a-8afb2511c1ee",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "af26cac2-a878-4017-91b1-85751aa8d0c9",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "7f7b8cee-03b1-49b6-8cb2-f9cd104900ac",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "2dc6d07c-f9c7-4ca0-a09a-8bd44af5485b",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "b3f72c7d-74ba-477b-bc01-35b93348d7b2",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "d00748c0-8a06-426a-9317-7a90501c0c8e",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "e027e34f-c0e0-4bfa-ab32-a0bd401b9053",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "82d9a93c-d2db-4c48-9ad7-13e9645993a3",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "0b910fd8-8773-47a3-aa0e-6af174c512de",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "ce897dca-6f51-46f2-9307-93daf618749f",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": "0a68d176-df60-48e0-a0c0-1c086bad3877",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "dcef8878-908c-4ac1-be5e-466a9a4d07a8",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "b6d628af-d135-4b0b-8c57-7ec08d0813fa",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "a41eddaa-ba7b-4bae-98bb-04e837871aa1",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "d0e08fc5-4bae-48dc-a78e-0d5f503ecc29",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "79588885-ab9f-4f3a-ad0e-5bea0953259b",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "9333c7e5-374b-47cf-9a4b-a9064fb9b8d9",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "2fa64364-272a-40d1-8a45-fe3ccb47f9f3",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "ab3c4d7b-e2b5-4c9b-adb3-0ff2df46be68",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "ba204ce6-a98d-44dc-8fdb-730f9caf6f59",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "3e7ef108-c5a1-4f94-b764-c70449a2699d",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "d909e5c2-4216-4328-bd8b-1926bb6318c5",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "b8f31e99-ef59-4adb-a081-eac9d94bfb36",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "b78a63b4-b0e8-49ea-af22-86badd98cb5f",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "ae2d8409-4397-4306-aede-be06a2f2701f",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "eff1dd40-f627-4b2a-859f-adece1303f46",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "9ecee129-b0df-424a-a3f9-15e988194f33",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "5903c5c3-b77d-4b90-b9e1-81c40f1b1d54",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": "51826d55-2ead-4328-b096-0bb91bf2cccd",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "ed4b7ab3-733c-4ac7-bd52-ab847e30cdcf",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "f5e4c44e-5c10-4977-b7ec-618a63be8239",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "bfe68d6b-fc4b-4ac2-84e3-85162aa9f0ba",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "27c9ab1d-7b3c-4f1d-aaa1-7ed07d022816",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "aa69ac48-8c60-4a3f-a18f-35ae256532ad",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "1d696719-070e-4e0c-a8f5-3e974a239d98",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "89820895-3db7-4ab1-b44f-622c12a55469",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "e65b1708-f6f8-43f9-8fe0-440a6db1fdee",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "8d9287b9-da1b-4072-b55c-97e5c0980621",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "7062d3c6-1645-4577-94c2-5eaa7ed8cdd9",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "2f94652b-bb5d-48b3-a887-0ffa3ea633b0",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "f3e22564-eca9-4ce3-bfc5-4f1aa39ac903",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "e0cebfeb-a2b1-4601-b177-e32fdbac018f",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "734ecd28-f4be-43c3-ac37-697c4fe96357",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "2d5b153a-b0eb-4591-b1a1-52ee24800940",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "67e38b39-679f-4a5e-98f1-b01c8af85c38",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "295ed595-a485-403c-b405-e67f4b93cc71",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "4a2bc0f4-895a-47ff-9d57-e43dffb3c827",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "6af98589-b0f1-4aa1-ace4-743e5e35c024",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "352da777-dbe7-4084-a56b-0c2a73974d0e",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "ea86f4b4-1ae7-4f91-b4be-6f3ecd4c43ae",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "109c1a75-cbc1-4846-9e13-c4c79fabab46",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "a41cda3a-8ffe-454d-b2c5-61c85b13c2be",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "ebb0ce1b-130e-4aa6-9375-bfa7a6886581",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "0c86c11f-f94b-48a7-8777-5d0f4b05c9aa",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "ee507176-252d-483f-97ef-548de6f24f53",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "e7d4bede-94bf-4031-b208-804cef52a637",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "33e2543b-452b-4423-b9bf-2402a2656159",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "6d7ad8b6-75d9-4528-ad85-59c8c8384778",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "5c9bfc32-8c24-459f-bb5b-5616565cb18f",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "38615d4d-d8c4-4ecc-9617-83dda336a145",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "f49fdf87-7b43-4bc8-8c14-c1aae2a5229c",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "2d79034e-c33d-4c28-baae-7decf859ee3e",
+      "code": "",
+      "length": 8,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "8cfb5623-def3-4996-b81e-ada15a7e4810",
+      "code": "self.setXSpeed(18);",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "e2d782ea-7ccb-449c-bdc2-375438a2fc5d",
+      "code": "self.reactivateHitboxes();\r\nself.updateHitboxStats(0, {damage: 8, knockbackGrowth: 45, baseKnockback: 75, hitstop: -1, selfHitstop: -1, angle: 60, reversibleAngle: false});\r\n\r\nAudioClip.play(self.getResource().getContent('special_down'));",
+      "length": 2,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "e33f0b3e-9629-40d7-9643-aa0950756867",
+      "code": "self.resetMomentum();",
+      "length": 1,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "748168bf-a313-4b7f-8648-d27f119dbf20",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "49c2203e-619f-448f-9626-b4ce6053f8ec",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "59c3a39b-f8bf-4a27-beaa-a387985799ed",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "6771b8ba-f3a4-43cc-be87-abeb65788d56",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "8f6f4073-8d2c-43cd-ba93-51bc29a2ba98",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "d583dff7-af44-4d55-a4eb-a4661042d623",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "81f6b67b-d9d4-457d-9b78-878a814cde6e",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "fd204bf4-66fb-4376-b05e-ce98c6098e03",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "a793b4d4-5f1a-4d3e-88a8-25db0dff9457",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "fd3506ea-a0c1-435a-9705-af5dbdb17400",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "b1ad6da4-3254-479f-8a21-339b2c17a5dc",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "de707ffb-3a19-48d7-8706-5f549f61ff7f",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "8830744a-3665-4a7a-ba59-57f5257c5a24",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "aead5f6a-ba5d-4ded-900c-73ab3be0a6aa",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "0ff04713-c8ee-4c22-a2a3-af2c511f8a18",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "2dbc6e7f-e7c2-4e59-8343-6e1d566d9269",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "2050513a-608f-445f-a976-1e6f8574b5cd",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "a3cd3184-4e3c-4ff3-b983-017d4d78f7f0",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "6acc9cea-cfdc-42e3-a9cf-a502fa85b709",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "d561a09c-e8f8-4179-8488-7a4f85527375",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "e2c189cd-0ecb-4241-9242-a8c2452b49ee",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "f50de00a-715e-4d81-ac2b-ef045592d0cb",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "4782e262-e201-45f3-8649-a827a13142ce",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "c6c84fee-cd4d-469b-922f-aafc5bf3601b",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "10489cca-01f1-4b78-bd16-d9c6182efeca",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "47ba628e-4f9f-49c0-914a-d525bd94b6c7",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "2f94c747-4ba1-4941-8293-73a39eb08cbc",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "4c371108-66ef-4e42-a986-c286f33b036d",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "bd4a870a-cec0-46ee-a446-ff6d5f583eb3",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "81e5df2f-3a75-4778-8a69-325dc0ac0798",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "f76fddec-3605-4d93-9557-cfc3270706e7",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "5f5d1914-37ef-468a-a626-9f94ec03058c",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "bb042f6b-0050-47c1-88a0-e15b3bd6c985",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "e92432fc-7860-480f-b1b9-bded83e70f47",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "f20697c1-8552-4ad8-8563-6f7ce1174c04",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "d321a9f8-740f-492e-a6b7-7307f804725c",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "3e74b9ec-97dd-4f7d-8aca-b4ba217dee5c",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "32185e7d-efda-416f-b2d3-9406c15cc9a1",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "00b79443-0d18-403a-8e0c-5f1eac8e3720",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "d829f9df-c220-4c10-b0d9-aa87a5a12b50",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "07306b8c-8ae3-4b7f-a66f-3728f3497f07",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "5e8f5e00-2fc8-4ea0-8316-b2cb147587b6",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "179c11e0-6f9d-4b24-bc82-1c5b5f0a1ccd",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "5f89421d-93f1-4a53-9155-420b638b230a",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "a56ebd03-e195-4970-a330-ec3060c64cd6",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "769b7acc-0785-4509-a73b-3a66f1c9c87b",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "6f8e23f1-3d1b-4e8d-8712-f86a91db454b",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "6b2582c6-1c23-4fdf-9e03-59ec2cc05339",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "3a539e1d-fffc-4aa0-8bf5-84b7aedc54ff",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "80d75919-4b91-46ee-83c8-fe96ddae18c4",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "fa979022-1ac6-4d12-9f9f-7c5bc2606766",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "da785d6b-7ab4-4c06-b80f-27d00b1b8159",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "501b4048-3a6b-4044-8ef9-b30e6f29f8c5",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "628ee882-25e9-4c00-b0d3-0b0965998453",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "528e5b43-01ce-4074-be92-fccf2890597a",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "5d096ade-4ab2-402d-833d-dd72b8aff669",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "cfe59698-994f-48ec-b7a0-1d8c05722dcf",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "deacb650-6b17-4e82-a294-e83be238d48c",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "5f806657-7bb2-46ed-9fd3-43d4834d9b32",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "c270d362-31c0-4264-9f0a-271752cba31e",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "0691f72e-fe54-4f22-825c-9a56d6b34d26",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "d7e032a8-c110-4338-92b4-2b859b6f57a2",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "b868d4de-59c0-40b5-a5df-864d3b7cd4bf",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "342ac47c-8311-4d23-843b-e82ab8acef9a",
+      "code": "var curr_charge_frames = self.getAnimationStat(\"chargeFramesTotal\");\r\nvar max_charge_frames = self.getAnimationStat(\"chargeFramesMax\");\r\n// the first part of this check is if they let go of special\r\n// the second part is if they charged for the max allowed \r\n//   - if u remove this, u can keep holding the attack at max charge\r\n// if either of the above are true then play the attack\r\nif (!self.getHeldControls().SPECIAL || curr_charge_frames  == max_charge_frames) {\r\n    if (self.getHeldControls().SHIELD2) {\r\n        self.playAnimation(\"special_down_clutch_attack\");\r\n    } else {\r\n        self.playAnimation(\"special_down_attack\");\r\n    }\r\n} else {\r\n    // otherwise loop the animation\r\n    self.playFrame(1);\r\n}",
+      "length": 1,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "08874d02-b6be-478b-9bc8-76f4bf18b746",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": "a00379b4-1be3-4864-9b24-1151b50e2c2c",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "f2ce1647-e218-4b8f-a6a1-02ce813ef4db",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "7bd7cea0-4564-4a03-90cc-0096f3299c5d",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": "60ffeed3-12da-459f-9f58-6443379a6563",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "POINT"
+    },
+    {
+      "$id": "9bd6ed14-fa5f-40cb-8794-fe1efb035dd4",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "POINT"
+    },
+    {
+      "$id": "f4bef144-f625-4012-8d76-373187739000",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "fef82d5a-3246-48fc-b39c-69a7554c678c",
+      "length": 2,
+      "pluginMetadata": {
+      },
+      "symbol": "cd298235-0c60-4f22-a49c-b85bc480c91f",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "bf788f2c-cf0e-430d-b499-e50bafae23c5",
+      "code": null,
+      "length": 1,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "506d7ec2-9863-4449-a086-9d3c4921eacb",
+      "code": "var curr_charge_frames = self.getAnimationStat(\"chargeFramesTotal\");\r\nvar max_charge_frames = self.getAnimationStat(\"chargeFramesMax\");\r\n// the first part of this check is if they let go of special\r\n// the second part is if they charged for the max allowed \r\n//   - if u remove this, u can keep holding the attack at max charge\r\n// if either of the above are true then play the attack\r\nif (!self.getHeldControls().SPECIAL || curr_charge_frames  == max_charge_frames) {\r\n    if (self.getHeldControls().SHIELD2) {\r\n        self.playAnimation(\"special_down_clutch_attack\");\r\n    } else {\r\n        self.playAnimation(\"special_down_air_attack\");\r\n    }\r\n} else {\r\n    // otherwise loop the animation\r\n    self.playFrame(1);\r\n}",
+      "length": 1,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "bb2e5f34-ba88-4f7c-ab96-79ca74a18052",
+      "length": 1,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "d2208c9c-4860-4911-90b7-7e99e0200d9a",
+      "length": 2,
+      "pluginMetadata": {
+      },
+      "symbol": "72470018-6cab-4e08-bb3c-9f78b5c43aab",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "05d4a2d4-c388-4e30-99d7-be79ef7aa5bf",
+      "length": 2,
+      "pluginMetadata": {
+      },
+      "symbol": "c6b84e6b-b56e-41d0-aa15-9e208b2c25b2",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "69a26144-0d34-4868-9687-a66888017e9f",
+      "length": 1,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "6302ecfa-a95c-40b6-9934-8bed0be57c17",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "6970d19e-06d6-46b9-954a-0f1d6a1f9c4a",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "857674f3-4a1e-4fce-ab55-5b2edd68d98d",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "f5e6ba99-8df4-4a4d-9bf8-93dc9db9a7ec",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "129fdd4d-4eb0-45a6-98e3-7a67d143c7d1",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "1d0512e0-5345-4f53-a391-5208a62860f0",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "f6d1debe-9f7c-40ef-b8e1-1e97d8de1a5f",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "ed699834-5613-4b5d-8b1b-b55cd73f8f68",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "486983d1-d5c7-4c20-bcd8-85bb8d2ace48",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "b2eb3c68-1d96-44d9-acb8-86eabe73b731",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "cda88091-67f4-49c8-9089-4778f58a3e94",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "d16b0ec7-bdb3-4538-8e93-5ea93d0bd9ed",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "e95dff3c-31f4-4156-8c25-d69df922f406",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "c2463073-933c-4152-8209-bbfa3bbb1ce1",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "a7e16582-7251-4adc-ba85-475cfc09eb1c",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "15341bd5-da45-45b0-8964-868cdc64f3e9",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "ed97162c-6a57-4836-885d-0aa5ef3cb7ce",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "9abfee64-0921-4cab-a95e-2a7a50ed961f",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "032ebf54-a70b-43de-92e0-f7ff5db6e644",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "f0831363-3d39-4163-85ad-60022fd8b3f8",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "c83afa69-cf79-46f3-8a6e-90d54ee8761c",
+      "code": "self.addTimer(1,36,function() {\r\n    self.setYVelocity(0);\r\n});",
+      "length": 8,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "c9486204-797e-4772-8d26-8e498e95f7ef",
+      "code": "self.setXSpeed(18);",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "6bab9d94-ccb4-4744-b27e-1e75e07a99f7",
+      "code": "self.reactivateHitboxes();\r\nself.updateHitboxStats(0, {damage: 8, knockbackGrowth: 45, baseKnockback: 75, hitstop: -1, selfHitstop: -1, angle: 60, reversibleAngle: false});\r\nAudioClip.play(self.getResource().getContent('special_down'));\r\n",
+      "length": 2,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "8c4994f4-3b1f-4e0e-bf92-9fb65ada56b4",
+      "code": "self.resetMomentum();",
+      "length": 1,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "6bfa043e-83ba-4b06-a529-7bffbaf8d2c6",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "29434f8a-2287-416f-8548-61cbdd83ba07",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "c1207acf-e0f2-4e4c-b28c-4f428d936e52",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "68ed4bb5-8e7e-42d7-89e2-cc67fe66863e",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "07c42286-86cd-4948-950f-488dfad54fc7",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "08cfeba3-9b33-43ed-a03b-5d82592d91f9",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "ab32d42f-7c0e-48a2-ba89-7a76fe2b9d49",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "0fd5d17c-ccf0-4532-a73a-947cfab051fb",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "30810c91-9fbb-4014-a404-5f887bb05215",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "ef421623-7937-47a8-bfac-dc2aa9f281ff",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "061fb687-a287-402f-88a2-b02dfcbcec37",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "273a7055-ddf6-4e5e-a241-a599064e5967",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "c3ac0fa1-3b42-4c92-a5ee-ea5a388c7b6f",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "6e427413-0b6e-448c-8065-ea1a93b22ef4",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "d19bc98a-91d5-437a-ac88-8b89c84f1fec",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "1f38f281-0b2c-45a2-809e-297d661d4471",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "1da211bc-4931-4522-8e98-dfb514b47853",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "8cc22bc5-e8c4-4501-acce-06fac5313091",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "78370598-bf6f-4a0a-88ee-40ca1a0ceae4",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "03abb5f0-2fb2-4ff2-8fe0-460292191f30",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "ebc6a1e0-f5b6-4431-9db3-19668b14e17e",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "f0784442-f0f1-4d2a-9ee2-bb55a57bcda7",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "d06dd064-5ece-4ada-8f93-d623100c53f1",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "67b07ae6-8375-4810-9adc-0cc17bd14cb3",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "651b7afa-b2f9-48cf-b658-1cdff5be325d",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "7c3755e3-7cd0-44f4-981c-75395785dea4",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "ea359c51-c03a-49a4-9a5c-210243a9a5be",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "2e0e22e8-3be5-4f02-952e-f3ca57f7015b",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "ac10267c-0268-4f4e-9bf3-40ff2b3bddad",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "ca73c1f6-20a4-48ef-a054-5f6ba5032805",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "5a96e944-6dab-42ea-9f48-771109dd8b27",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "b840702a-89f0-4c05-8cc0-c8c048d47406",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "ee23e587-5cef-46cf-af2d-b8d1176f052e",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "3a539d95-54de-4dec-a952-a65cce3dbfab",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "60e5b667-2ca6-42f5-818c-79c162c0af4a",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "b817e5d8-4727-4079-a02a-a0589e66980a",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "7d0d8dac-3504-47df-a44a-cf3f162af14c",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "fe5aacaf-aa21-4095-91ca-fc9a99db49a3",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "b98602de-34cf-4db7-924c-486fe4c106ee",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "e0c879cc-efa9-4754-bb33-afa119a73213",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "aa0ca4ae-6ca3-41ec-aa66-1eb9f2c33d26",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "9112d092-635a-4bf6-bdab-1f3e467b49ee",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "f1c59225-000c-4842-9da0-fb183b744474",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "ef84ba4b-b021-42c1-8ce2-6bc457d7be35",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "636f0398-7b19-4519-bde5-081dda613658",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "02d94454-8342-4cf9-bedc-b77864c2fb47",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "701c5bdd-ffef-415e-8a5a-29e29e81743b",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "6f2d69e8-d65c-4782-b5a5-1bd7f1605a14",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "176000c5-eb98-441b-a598-e049699169ed",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "20e42e5a-18d7-41f5-b4a7-e46e12736c9f",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "6509afd8-0f8a-4ca8-954d-adfe668239f2",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "9b67504e-97d6-47cf-bcab-5ebb1b8a9a97",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "1befff16-6ed5-49a8-be7c-32472d85ee43",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "08567461-7a0b-480c-ad40-3a170a64b685",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "6b7b29b5-f0f6-4300-a8b1-a180a281f096",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "ea391bfe-54a6-4dc1-9a6a-850071896c5f",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "e597f38b-5243-4cf1-8d3b-9d8e137690d1",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "54911e60-3d56-45b0-8a6c-0f0f3cc3ebf2",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "0b6b7163-663b-4f10-bf21-0eaed7cf2ae7",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "cab45102-af4c-4173-a05d-450c4e101ca3",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "4b7cfe46-29db-4df2-b98f-6b21cee37d8d",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "5cbd436b-8acb-40ff-a8ca-c8628bff5678",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "67e533fe-156c-495c-afa0-30c4dfe1adac",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "90262c6a-e56e-4b75-a8f3-d402ca789a80",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "7d45fd99-adcb-4a64-b5e8-40d2c55e9021",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "46adbed8-b470-4c8b-8ca1-84ec2f0a4400",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "a03d49d1-978b-4cdf-8a1b-379ccbdcb710",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "9621b72c-0408-4021-b96f-70e66e361918",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "80f69c48-3f6c-4565-941f-ab3ca9991c13",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "92ef9d53-7a57-42bb-a484-b82a94d252b7",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "5e311d2d-ecca-441e-8338-888999139bbe",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "aedec2b8-c47d-4961-96bb-12426e7cd1df",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "b7f49f32-9cf8-4c3d-b81b-164f8d5eb1a3",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "95fcf100-ea68-4737-935c-9918ca81ab06",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "6586f3cc-6c5a-41d8-8a6c-d1350afc7cb4",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "82b3b5b2-3155-4aad-8570-bcd537cf4199",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "1c9cb5cc-c2de-4f18-ba8b-aa6c3c0e7d21",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "10d0ca60-ea54-47e9-940d-ada5335f1e8d",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": "9c60563e-413c-4cd8-80dc-59fce8969407",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "24936b7f-97df-4ca9-bb5b-17630df9ecbc",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "c4ead9ca-bc78-4699-8e53-3e9a568d61c3",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "9741efa3-20d0-4b24-89e2-7e41597a87c8",
+      "code": "self.resetMomentum();\r\nself.updateAnimationStats({gravityMultiplier:0});",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "8f5318bd-58e0-4581-a695-84b2acb79935",
+      "code": "self.setXSpeed(18*(1+self.getAnimationStat(\"storedChargePercent\")));",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "fd66f4ff-98a4-47c5-bd56-4531a6b649a2",
+      "code": "self.resetMomentum();\r\nAudioClip.play(self.getResource().getContent('special_down'));",
+      "length": 30,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "c75bb6ae-a074-468e-9971-c6204f42e299",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "e6973cb7-d691-42c1-87bc-2492cdac153e",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": "dd6280d4-0ade-45b9-857e-24c85cb5d8b6",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "27965267-14ad-43e4-9cbd-193ba464423b",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "POINT"
+    },
+    {
+      "$id": "78e7e9b9-5d8f-4393-92b7-707b07e6b580",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": "2f977c8f-c8b1-4fc1-b54b-78df16df06d1",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "POINT"
+    },
+    {
+      "$id": "0e60cbc6-68aa-4962-a711-a7381ff51242",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "3e8f93a6-1f54-4a9f-bc5b-9d2d3fd2aa3c",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "67ab96eb-a7c9-433d-b613-e841f4b62b6b",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "fff8b0da-48e2-450a-998a-46efa8041bd5",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "09effe79-a92c-451a-9fdc-825a70c3adde",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "117b1ccc-eaa6-4cf4-9db0-7fb7c2c0abb8",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "cbc81609-c933-45fb-b723-13d0c399fc68",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "d3d51252-2062-4b1b-bef9-e5636d62ad84",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "04a43931-820f-4427-baa1-1604e9b92525",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "c47975b2-5941-428d-b0e7-c83293101151",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "1cafed36-6bba-4ceb-bd8e-2632b44d6559",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "3b7bf515-d876-413e-82ae-f8b4db307a09",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "d15167b4-aadb-4b4c-b58d-c69bb8326840",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "18bea265-67e0-4622-9143-6e97f5d28451",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "3afc7df9-07dc-44e3-b88c-e741ac763da0",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "2b5506f1-5337-46ad-b8c0-854625111b0b",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "290d35b5-eacc-4408-abd2-ba264240bc2c",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "c74ace8c-3b13-4b78-85ff-9536b0aafea3",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "0b1aaa6e-7ca4-419f-840b-0947a9e86248",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "c6fa297e-f971-412d-9d62-e30b12927809",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "03f1e076-0f2d-4b0c-b793-8c3ca3cc33ed",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "bf275da9-d932-41c2-9652-91cfdb02c33f",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "b7bade6f-1d00-405e-b73d-0067e16b7433",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "12b54ada-b4cd-46dc-9c4b-98742e5ddd03",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "0828424d-1e31-4f4e-b564-e76e282fc836",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": "1a1fc8f3-e2b9-44d8-8f58-1ec9b2028905",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "30669ac4-19cd-48f0-9d62-87696c0d3e29",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "24ab7202-bb3e-498d-9494-4eb0603a36a6",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "e4426f8f-af9c-4329-a3ad-66930a2f8d3d",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "e8423a5f-d61f-49d7-af99-27e1719efd7a",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "4c396626-dac0-4fa3-a154-88785c91b7df",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "7c5504d0-ea58-457c-930c-fd478e31d99a",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "52532d65-8042-4d40-a629-64df365f263c",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "da88b418-07c9-4ba6-b817-4e3750ef8e61",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "16c8c95c-9083-4b88-ac61-adefccf116c0",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "ee8212f7-ad98-4932-9079-1cc56f8ed00b",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "bbaf2405-f26d-4fb7-938e-486c02fb1f96",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "07f2ba3d-54f4-4a87-af84-78f4d0eaea3a",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "1f856e7d-ccde-438a-b549-348865e2a96d",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "0fca7108-66c9-4f34-96b7-758e40b1ead9",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "503469f5-f93b-4a63-9e2f-a5ac52ba29da",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "7b137eac-0aff-4917-9b2f-9976c9061ffc",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "6116b323-44e7-4811-b683-786726cdab94",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": "67704b35-576f-44fd-b921-d66603e72937",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "dbc77ce0-58d2-4f10-9059-5d4b6235dd22",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "9a750016-fdcf-4ab9-bb0f-5e99d56b32d7",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "47124092-a5b3-4fd1-8c21-a1aaabdbe9cf",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "228bc995-11a9-49b7-bd74-90d599d4355e",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "86dd6b66-5a73-475c-9ca0-be9f4052578a",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "f9e522ec-d8bf-4d47-b9e5-6b6d2a62cf64",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "015736d8-eaff-4441-a4ba-f3d246ac9129",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "088eef7e-81c8-4dec-ac0a-413ccc941678",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "921b682e-8802-4e35-896d-25c3769da2f3",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "c45d5618-93c0-4158-8555-fb8f3cb81210",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "461103d8-b66c-4243-817c-1b9fecb73ece",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "bad58692-b695-44c9-83d2-f347ed08ce73",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "95743d91-a0fc-4b7f-8e0a-fbab9082a23b",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "04b32d97-56e4-427f-90ae-3757e1c3e31c",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "7899227e-93ce-412c-b5db-d0307428a711",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "8a13c4bb-acb1-4adb-897a-d5e0868b7c18",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "b01ce571-5b51-434e-bea3-9842fb6bef6e",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "c7b70d0c-3a66-473f-920d-28d3e08199bb",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "9922e266-bc95-4cf6-bd95-e263bfd999e7",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "f74dff87-0266-4c4a-8a11-67aa88583978",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "8318f215-4fff-4251-9dad-b430903726da",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "64e8684e-9029-41f7-b7b9-cae544b9e1f2",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "1798a013-8281-4e72-a268-67b1bb30f519",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "b111e866-80ba-4a83-bff2-0a0d58538d0b",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "7e605f55-05a4-4f3e-8ca2-9a908aaf32a2",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "974465f1-eeb2-4200-a060-29e5c7110ae1",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "2080c435-4960-4fdc-b086-bc4a65a2be7a",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": "96107c2e-7f6b-4123-bc3f-083fa99dc995",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "2591c2a0-9f92-4e4e-9f05-071cca083b46",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "c662237d-d9bb-4ef0-8688-485445cc6732",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "IMAGE"
+    },
+    {
+      "$id": "bf22fc2d-65c7-4f69-8932-72bdee6cb40c",
+      "code": null,
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "49abeeaa-8ebf-4a1a-9b2c-865742c0232e",
+      "code": "self.setXSpeed(18*(1+self.getAnimationStat(\"storedChargePercent\")));",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "bf5ad2cd-107b-434c-9a93-432b4a1f1c03",
+      "code": "AudioClip.play(self.getResource().getContent('special_down'));",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "0c919a96-7ae4-42d2-962a-ae7273fd386e",
+      "code": "self.resetMomentum();",
+      "length": 33,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "2d39611f-a63c-4a10-b7d6-4eac7085ad9f",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "8e17d3b9-eb33-4f82-a9ea-974bcd597d08",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "2730eb3e-f8ca-4ee9-9a8b-c30f66dfa518",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "63db6c70-d7c0-48fb-9235-88022679a5db",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "913ba1df-7b1e-4dcb-b856-81712e6e336a",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "7bbed9d6-d742-4dad-80b8-77f3fc602418",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "8804528f-e8d3-4d0e-8543-898f5e620a02",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "e631131f-079f-48d4-96dd-1a9e1c8af67d",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "ce86aa04-f3d7-4030-9936-16ad20331209",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "28355437-102d-42fa-af0b-4bdf5ad67ff5",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "dd002905-cbd4-4c75-9009-dab93b773a6d",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "37f505af-5f81-443b-8f3d-726f10c6ab89",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "9c448209-b4dc-415f-bb11-b5e8a7693080",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "41272ba2-aa79-4249-a874-bdc69686867a",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "0c0919bb-c09c-4af8-8a9a-c954547da54d",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "b067dd07-932f-4ffa-8131-3f2353f0abb1",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "ecbbd826-b3c3-4cde-b4a6-b28d373eb486",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "e5b6fe1e-569f-4792-a926-2746163ff972",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "270df3c9-2225-4431-9ef0-463b1225bcb2",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "b6ff9ddf-889e-47b8-b28f-9fd919cbdc26",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "c35919ba-08b8-4ffe-91b7-765ba082afdf",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "1a325b28-6eb5-42c9-9732-ce58414fc121",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "273cf904-3068-43c0-9046-9a5610511333",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "5e09755c-be84-436b-90a0-b014701efdf5",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": "456997e6-d424-4470-8d85-a2a24ce09ba8",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "7d0c96f2-278f-42b4-bb5f-0ef1025bbc0b",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "31b0c769-2d24-4d3e-8592-1e2a0a0d6731",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "93be23b2-eacf-475b-9335-444d5d72bead",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": "81073ce5-a0ae-4a9d-8285-5777806f77d6",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "c8077ee6-a1a4-4a81-aaa2-d9bb870b852e",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "5c5e3e71-2d65-4ad9-b863-d33df2d20730",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "52f75a68-5d7c-4d57-93e3-8e72a7e34dcf",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": "f06767d6-f5ab-45c8-8375-5e2638870093",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "a8a92787-c93c-49c7-ae67-46f8e2bb8dc0",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "4350b0ad-710b-4d86-b2ec-971a7b601715",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "05d5804c-d035-4126-91fc-910c960fa1d2",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "23dc3bc9-b253-4565-aab2-10deaebf9bbb",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "647f15fe-bb5f-45fa-9730-e733533616a3",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "859ed466-ad66-45d0-aa3b-8650c0ec6786",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "d56ac7c6-4e12-43f8-823d-d9b433d1e165",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": "c7903084-4165-4a23-9974-f28a95d0c7e1",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "f373fd6a-5cbb-4cb9-9c64-f5826002eb02",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": "eaee934e-9a70-4fcf-a092-e6af1cfe2012",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "33bf9d44-e8d2-4c81-bb28-f65c02d54101",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "8151c409-fff3-498e-b20a-f3ee26aee679",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "ae0c6952-0bf1-49cb-8f00-e8129c100fff",
+      "length": 3,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "a57d2841-a6b5-46e4-b62c-facdc6c6d4e4",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": "e985190f-265f-4ea7-9966-8960a6654448",
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "01fedaa3-f032-4423-bd0e-47a703ed19a5",
+      "length": 4,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "4c76e275-3c09-43b7-af48-478059b5ad38",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "c450ce55-b0ff-4a99-9608-cfc2051838c5",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "a42200d1-ba56-4a76-acab-1b08c95387a5",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "8ac7f9cc-31f0-491f-a614-d672d94c1cf0",
+      "length": 5,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "35c5fbfa-0152-4152-a3de-2c88ff769f75",
+      "length": 6,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "13886e99-4e73-4dd5-8b6d-d32f5dff138f",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "f1d1f494-5bd3-4cdc-92ba-a24fcbfa9c3e",
+      "code": "self.updateAnimationStats({gravityMultiplier:1});",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "6c5740dc-cea5-4ab0-872a-e366fc99b18d",
+      "length": 7,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "25871ec8-4030-4d0b-a443-bbf5a2525768",
+      "length": 38,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "POINT"
+    },
+    {
+      "$id": "0860b8c2-e7f2-4c17-8e36-73fdda7a783d",
+      "length": 38,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "2eaa6483-0e0f-4759-a6d0-bd62b6277234",
+      "length": 38,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "POINT"
+    },
+    {
+      "$id": "812609fa-b704-483e-b9ae-e5d90b33c7ab",
+      "length": 38,
+      "pluginMetadata": {
+      },
+      "symbol": null,
+      "tweenType": "LINEAR",
+      "tweened": false,
+      "type": "COLLISION_BOX"
     }
   ],
   "layers": [
@@ -42427,16 +44335,7 @@
       "$id": "4c6456ee-7098-49ae-b7f9-61f69e11d653",
       "hidden": false,
       "keyframes": [
-        "572980b8-bd33-4f13-8d31-a721017a9951",
-        "a88e3fac-a2bd-4521-88fd-5f795e76248a",
-        "13ed764a-8bfb-4d55-8c5c-eac762d186a6",
-        "166b31a1-4533-4cc5-a90e-80a85fae865d",
-        "4fd4cd36-244b-4e79-9d5b-e9e66a13d04b",
-        "37aa0b13-3e2a-4d3d-9de1-2c2ea9758a52",
-        "c324607e-6267-49c2-b829-0e69c337ca0c",
-        "6d9f79c3-16d4-4f8f-a61f-0d9baa3bede7",
-        "ca07f7ce-3bfe-46b5-845b-b35bb99a3a96",
-        "8bff24d3-c407-4354-a2bd-48fa2f412fe9"
+        "572980b8-bd33-4f13-8d31-a721017a9951"
       ],
       "locked": false,
       "name": "Image Layer",
@@ -42450,16 +44349,7 @@
       "defaultColor": "0xff0000",
       "hidden": false,
       "keyframes": [
-        "ae9e8cdf-5c24-4e47-8ab6-ff6002864487",
-        "5a0d3685-8042-4c52-aaf4-c4fd0248183a",
-        "438e1b51-ac1f-4e61-af56-211a71a7214c",
-        "eaa97071-c6a8-4717-b413-05ed20c7fe2b",
-        "6b9b5427-261a-4b99-a689-7b9cc5ed377d",
-        "2c2e816b-5d1c-448d-86d4-14a24da7f19a",
-        "f43b221d-65a4-41c4-a2e0-47480e2fa81e",
-        "d680ad6b-c7df-4450-a8f5-3fa664a5bb22",
-        "96288ec5-22da-4823-ab39-d34ddf4198f5",
-        "e9cdff04-4476-44ab-9014-ae92c25d312c"
+        "ae9e8cdf-5c24-4e47-8ab6-ff6002864487"
       ],
       "locked": false,
       "name": "hitbox0",
@@ -42477,16 +44367,7 @@
       "defaultColor": "0xf5e042",
       "hidden": false,
       "keyframes": [
-        "382cae67-6f12-4c43-9821-44ff59d87c9a",
-        "1ada0ba1-7737-4fd9-98ab-97bef5c4d220",
-        "8454cfc8-43b2-4f68-8dd4-4c7bf1810407",
-        "56b153f1-8b49-427b-b272-491b29bddae7",
-        "efd3a5f5-c1ea-4649-b3ca-66703676a3fa",
-        "c21e1713-8e8f-42b3-baa2-4356b0c9754c",
-        "9d0f1e23-1216-46fa-adb6-5e4443b764aa",
-        "227ba522-2fe6-4f2e-a937-6d60e964c975",
-        "b7da70e4-f941-44f3-bd62-f26d867c225a",
-        "76ac3877-4e9f-4057-9781-d8331fae2d41"
+        "382cae67-6f12-4c43-9821-44ff59d87c9a"
       ],
       "locked": false,
       "name": "hurtbox0",
@@ -42504,16 +44385,7 @@
       "defaultColor": "0xf5e042",
       "hidden": false,
       "keyframes": [
-        "6a6f6d81-50da-40f3-98de-bfb11917b002",
-        "67520320-8f94-47b5-b2c2-363f8d4bef90",
-        "8a749202-9dac-4f53-a47b-7f4fca5a2bbd",
-        "287b925c-3ecd-41b5-ab71-3b0a5f50227d",
-        "6cc9a940-1201-4187-a5bc-6fe343d9c8e5",
-        "b0e5a82f-9cf6-4cbf-bd3f-a0ee73487aae",
-        "b9105367-1796-42cb-97f0-069660954d8c",
-        "77db312c-8287-4827-ab00-be5d6e7e75d4",
-        "aeb9a001-cf66-440b-b607-4a2d8ee0d380",
-        "c43b13e2-746a-4bd7-91da-21458fe93c87"
+        "6a6f6d81-50da-40f3-98de-bfb11917b002"
       ],
       "locked": false,
       "name": "hurtbox1",
@@ -42531,16 +44403,7 @@
       "defaultColor": "0xf5e042",
       "hidden": false,
       "keyframes": [
-        "d090daca-990e-47d0-9f54-1a33c4c973f1",
-        "8820ca38-56e6-43b3-9783-f3340842a9c7",
-        "3ffe2826-a62b-4443-8702-e46987eddf22",
-        "82d9fe96-e00a-4bf1-8be9-1ebf3d20d93f",
-        "2c78bca4-ce3d-44c9-b9e1-e841bf4d355b",
-        "558391a3-2d3b-48d7-8256-aa840e552541",
-        "f92d603a-82f5-4733-8083-ec3771c7a055",
-        "7d99ecdc-fa6f-409b-8161-9cda38d75ae8",
-        "b7edc1d5-f9cb-4e90-a98e-bf3460a580b5",
-        "7071d38b-b8fd-4ff5-96c8-97b37ea0f899"
+        "d090daca-990e-47d0-9f54-1a33c4c973f1"
       ],
       "locked": false,
       "name": "hurtbox2",
@@ -46378,10 +48241,7 @@
       "$id": "d62dd291-f247-416d-8ca6-9730c3969ec6",
       "hidden": false,
       "keyframes": [
-        "3a2d5df4-67a3-49ec-9fdb-a5c07d74928a",
-        "f4e359e2-63ae-4428-9956-fff75e235520",
-        "6c47d820-90cd-4c8e-b390-b063fc4061fb",
-        "92bdcf63-b5a8-40a5-9152-361cca411cb8"
+        "3a2d5df4-67a3-49ec-9fdb-a5c07d74928a"
       ],
       "language": "hscript",
       "locked": false,
@@ -48240,16 +50100,7 @@
       "$id": "614f423b-708e-4404-b6cd-f167fb07df63",
       "hidden": false,
       "keyframes": [
-        "eb3dc6a1-43d3-4314-8306-eda1eaac9530",
-        "0f5e9d0c-50d0-44ca-b06a-8c130d97e4b6",
-        "0ba3961a-74d3-4fe2-9ef8-d498831f8e34",
-        "bd4f356c-caaf-4c5f-a7ec-ebd3f7ca10c3",
-        "57784474-0d51-475b-b27c-81fe3174297d",
-        "254062cb-fc1d-42df-bceb-4ed0c0f8712e",
-        "c73440a5-59ca-47e5-907e-6c253de44035",
-        "68b19214-89fa-4eb0-886c-a5987bfb5acd",
-        "244f0a85-d40e-419a-9bda-069a1c7dae7a",
-        "e60d3c19-d931-4992-9cc5-fe4450476315"
+        "eb3dc6a1-43d3-4314-8306-eda1eaac9530"
       ],
       "locked": false,
       "name": "Image Layer",
@@ -48261,10 +50112,7 @@
       "$id": "b47745dd-c0f4-4455-a290-66a16a1675ff",
       "hidden": false,
       "keyframes": [
-        "d4e80419-9d31-49cd-b983-d1535a0bc6b8",
-        "eaf74e2d-bbc7-439e-ad12-3aec18696b35",
-        "57735e9f-2621-4374-aeea-498be8de11cc",
-        "cef02b68-9f2c-4e7a-a828-6401371e3a3a"
+        "d4e80419-9d31-49cd-b983-d1535a0bc6b8"
       ],
       "language": "hscript",
       "locked": false,
@@ -48279,16 +50127,7 @@
       "defaultColor": "0xff0000",
       "hidden": false,
       "keyframes": [
-        "7a3f657b-a85a-4b92-9b08-3813d04aa885",
-        "8ab113ff-401a-4fde-9aff-0798496bf196",
-        "9357e1b7-0630-4d0b-8e81-408a562f8dd2",
-        "a3236be9-4afb-4cd8-9922-57270cef1cf2",
-        "f8d08be8-dfb8-4fb0-b55c-cecdcefb555d",
-        "5b837ad7-516c-49ac-83ea-64a312cb6e31",
-        "785de533-462f-420a-9585-9b79d5b7d23e",
-        "c8a46a7f-c8bf-4665-add9-3b26229f34ef",
-        "2dd78b43-db14-4725-906c-89a7ee1ad74d",
-        "81b0d7ff-ff0b-4f49-a7a5-0020019e242d"
+        "7a3f657b-a85a-4b92-9b08-3813d04aa885"
       ],
       "locked": false,
       "name": "hitbox0",
@@ -48306,16 +50145,7 @@
       "defaultColor": "0xf5e042",
       "hidden": false,
       "keyframes": [
-        "c6aa83de-c6bc-409d-8c30-629287ca6747",
-        "754b8add-1fa6-49cc-b6f0-989a52d06485",
-        "9ae5da2a-fc2c-41e2-bff2-d54e54efbaeb",
-        "b13911e5-d201-404b-b231-f075ff1d62b8",
-        "79b31dd4-dc68-46d7-8fc8-0f8dda73b2d2",
-        "758940d9-ad2d-4a48-b050-56757c24da27",
-        "d85ca943-df40-458c-b230-29213fc666d9",
-        "44b5971a-9167-4e4c-9b3b-309b16c8f345",
-        "e6b1d823-a395-47bf-86a5-58af668acabc",
-        "28391c21-6048-4f32-9cda-7eb9add6b4d2"
+        "c6aa83de-c6bc-409d-8c30-629287ca6747"
       ],
       "locked": false,
       "name": "hurtbox0",
@@ -48333,16 +50163,7 @@
       "defaultColor": "0xf5e042",
       "hidden": false,
       "keyframes": [
-        "afd77ddc-abba-4b45-b81f-1764bd32bef8",
-        "8d85c24e-f36c-43a1-be32-74d2dc2185f3",
-        "a22877fa-21b2-4f60-a1c3-c3c6d837c791",
-        "06f81d57-24fb-42c6-8c38-a9361b57b579",
-        "e1749500-243f-4ab0-89bf-05847810550a",
-        "f9634689-41f0-4fca-a5e2-05e7c4789f48",
-        "49a234aa-38c7-4682-8359-3fd601785ce9",
-        "fb851bc5-347a-495f-8036-e531f028b3f9",
-        "2c299c9b-19b8-45b4-99b6-58aaef26f630",
-        "79479f22-67b0-4f5d-83ea-5dd8dfe7f0d5"
+        "afd77ddc-abba-4b45-b81f-1764bd32bef8"
       ],
       "locked": false,
       "name": "hurtbox1",
@@ -48360,16 +50181,7 @@
       "defaultColor": "0xf5e042",
       "hidden": false,
       "keyframes": [
-        "c3e3e4b0-daee-4991-983e-88021c83ae3d",
-        "c140f969-5ddd-4acb-8e6d-b42406f90030",
-        "c09f6988-8985-49f4-b40a-c76259d662aa",
-        "2434eb3e-7f64-4454-9d9e-d2d06c1b1ba4",
-        "849f62dc-da7d-400d-a297-dad05e0872a6",
-        "e192b6fe-8deb-429e-a8e1-d5d870ed6e1c",
-        "580a663e-446f-4104-8de0-29dcce700242",
-        "020cda66-69d9-4d2d-a8c1-cdaf032c69c6",
-        "c0328e22-898a-4bce-9a53-a086a070cc13",
-        "f4f5dde9-aa19-420f-8872-a82afade0c79"
+        "c3e3e4b0-daee-4991-983e-88021c83ae3d"
       ],
       "locked": false,
       "name": "hurtbox2",
@@ -50660,6 +52472,985 @@
         "com.fraymakers.FraymakersMetadata": {
           "collisionBoxType": "HURT_BOX",
           "index": 3
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "51170727-2c13-40b6-b831-0d365c151c4f",
+      "hidden": false,
+      "keyframes": [
+        "42f73af2-b426-459d-b218-fcf3d85ca708"
+      ],
+      "locked": false,
+      "name": "Image Layer",
+      "pluginMetadata": {
+      },
+      "type": "IMAGE"
+    },
+    {
+      "$id": "ed1948ec-d1be-4bdf-afb8-63698277e9b9",
+      "hidden": false,
+      "keyframes": [
+        "ee2869c0-7371-4c1e-b679-b182c8333ebd",
+        "342ac47c-8311-4d23-843b-e82ab8acef9a"
+      ],
+      "language": "hscript",
+      "locked": false,
+      "name": "Frame Script Layer",
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "b37215e8-5f9f-462f-a344-4992d3b6f487",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xff0000",
+      "hidden": false,
+      "keyframes": [
+        "2877890b-dd10-4a23-bb6f-21485ad629a4"
+      ],
+      "locked": false,
+      "name": "hitbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HIT_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "7cc43a3f-e80a-4c6b-9aea-5fcf64318409",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "acc44348-d839-46be-aaa4-6e4464a9d523"
+      ],
+      "locked": false,
+      "name": "hurtbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "a416930c-33aa-4e5e-8f16-868759713ac0",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "d1175980-7a44-4b1a-8e09-915173a5de95"
+      ],
+      "locked": false,
+      "name": "hurtbox1",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 1
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "13d647f9-0475-4b5a-98a0-3c6d2ff28139",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "6b5ebebb-c481-4e9f-8862-7ef4792589da"
+      ],
+      "locked": false,
+      "name": "hurtbox2",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 2
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "611c51bb-0ec0-4f69-9868-e3ac592401f5",
+      "hidden": false,
+      "keyframes": [
+        "79b53f82-9551-4578-8ecb-a5c3bef9adf5",
+        "1969b03f-f920-4114-8ab2-982aa1c24433",
+        "226b813d-a19a-41d5-ab40-e33559c7ea0c",
+        "126cb4fa-598e-4dd2-a6d5-e6e00ec52669",
+        "648232f9-52d8-4c61-b981-c901706367ed",
+        "5ff01680-22a8-46e6-9ab0-bca73a40cd4d",
+        "e751ac80-8786-4d6e-8ac7-ad6bc73d41d0",
+        "f754edc8-be2f-4315-8500-f986776090c7",
+        "33c4cb32-3242-4331-9bf1-9991e937096d"
+      ],
+      "locked": false,
+      "name": "Image Layer",
+      "pluginMetadata": {
+      },
+      "type": "IMAGE"
+    },
+    {
+      "$id": "af8cce5e-b5d3-4476-bc90-bc035f46520f",
+      "hidden": false,
+      "keyframes": [
+        "0d025045-faca-44d3-85b6-578ed94acc9a",
+        "12dee63b-a78f-4626-b4d1-71a536815a78",
+        "db7f3f23-1833-472f-8c29-6b49e0049ceb"
+      ],
+      "language": "hscript",
+      "locked": false,
+      "name": "Frame Script Layer",
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "d0a165d5-efb5-4314-9f86-08569eb59f20",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xff0000",
+      "hidden": false,
+      "keyframes": [
+        "04f3f2ef-7b28-4466-8dab-3af200376385",
+        "f4bef144-f625-4012-8d76-373187739000",
+        "54655408-eb24-410c-82c7-bf8cbda75638",
+        "1e41ac38-2c81-4e17-acd7-c5aeb6be29c3",
+        "49c0122f-aaf2-4b6c-bd47-8f1f277ebe5e",
+        "9e9f30ce-f0ee-458b-8e91-9aa224a19cc7",
+        "c99ca1b1-54b1-40f0-9497-a28c883b14d4",
+        "ab411148-0245-4343-9434-f5fe473dd218",
+        "d2e6ec70-4bd9-4f90-9c77-53b6bf0a3900"
+      ],
+      "locked": false,
+      "name": "hitbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HIT_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "90e69ba8-a956-496d-b4d4-581731198653",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "c3ec950d-1c27-403c-a8eb-fbd5af68b9bf",
+        "e3375b77-dd8a-4f1d-a46c-e31750a4bf13",
+        "a704e43f-7c64-45b5-86fd-18d308ddffd9",
+        "af26cac2-a878-4017-91b1-85751aa8d0c9",
+        "2dc6d07c-f9c7-4ca0-a09a-8bd44af5485b",
+        "d00748c0-8a06-426a-9317-7a90501c0c8e",
+        "82d9a93c-d2db-4c48-9ad7-13e9645993a3",
+        "ce897dca-6f51-46f2-9307-93daf618749f",
+        "dcef8878-908c-4ac1-be5e-466a9a4d07a8"
+      ],
+      "locked": false,
+      "name": "hurtbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "fdb2e8e4-7729-4e68-8841-b9998a0292c5",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "a41eddaa-ba7b-4bae-98bb-04e837871aa1",
+        "79588885-ab9f-4f3a-ad0e-5bea0953259b",
+        "2fa64364-272a-40d1-8a45-fe3ccb47f9f3",
+        "ba204ce6-a98d-44dc-8fdb-730f9caf6f59",
+        "d909e5c2-4216-4328-bd8b-1926bb6318c5",
+        "b78a63b4-b0e8-49ea-af22-86badd98cb5f",
+        "eff1dd40-f627-4b2a-859f-adece1303f46",
+        "5903c5c3-b77d-4b90-b9e1-81c40f1b1d54",
+        "ed4b7ab3-733c-4ac7-bd52-ab847e30cdcf"
+      ],
+      "locked": false,
+      "name": "hurtbox1",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 1
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "9cf86571-8172-4e9d-8aac-f784aebbe20a",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "bfe68d6b-fc4b-4ac2-84e3-85162aa9f0ba",
+        "27c9ab1d-7b3c-4f1d-aaa1-7ed07d022816",
+        "1d696719-070e-4e0c-a8f5-3e974a239d98",
+        "89820895-3db7-4ab1-b44f-622c12a55469",
+        "e65b1708-f6f8-43f9-8fe0-440a6db1fdee",
+        "8d9287b9-da1b-4072-b55c-97e5c0980621",
+        "7062d3c6-1645-4577-94c2-5eaa7ed8cdd9",
+        "2f94652b-bb5d-48b3-a887-0ffa3ea633b0",
+        "f3e22564-eca9-4ce3-bfc5-4f1aa39ac903"
+      ],
+      "locked": false,
+      "name": "hurtbox2",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 2
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "dc5039d6-d97b-4686-9965-e0b9518e13cf",
+      "hidden": false,
+      "keyframes": [
+        "e0cebfeb-a2b1-4601-b177-e32fdbac018f",
+        "2d5b153a-b0eb-4591-b1a1-52ee24800940",
+        "295ed595-a485-403c-b405-e67f4b93cc71",
+        "6af98589-b0f1-4aa1-ace4-743e5e35c024",
+        "ea86f4b4-1ae7-4f91-b4be-6f3ecd4c43ae",
+        "a41cda3a-8ffe-454d-b2c5-61c85b13c2be",
+        "0c86c11f-f94b-48a7-8777-5d0f4b05c9aa",
+        "e7d4bede-94bf-4031-b208-804cef52a637",
+        "6d7ad8b6-75d9-4528-ad85-59c8c8384778",
+        "38615d4d-d8c4-4ecc-9617-83dda336a145"
+      ],
+      "locked": false,
+      "name": "Image Layer",
+      "pluginMetadata": {
+      },
+      "type": "IMAGE"
+    },
+    {
+      "$id": "639d968e-1602-4471-ae1c-2836796c9bc2",
+      "hidden": false,
+      "keyframes": [
+        "2d79034e-c33d-4c28-baae-7decf859ee3e",
+        "8cfb5623-def3-4996-b81e-ada15a7e4810",
+        "e2d782ea-7ccb-449c-bdc2-375438a2fc5d",
+        "e33f0b3e-9629-40d7-9643-aa0950756867"
+      ],
+      "language": "hscript",
+      "locked": false,
+      "name": "Frame Script Layer",
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "39bdfbed-b97d-466f-a85b-b6ba7d77ccc4",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xff0000",
+      "hidden": false,
+      "keyframes": [
+        "748168bf-a313-4b7f-8648-d27f119dbf20",
+        "49c2203e-619f-448f-9626-b4ce6053f8ec",
+        "59c3a39b-f8bf-4a27-beaa-a387985799ed",
+        "8f6f4073-8d2c-43cd-ba93-51bc29a2ba98",
+        "81f6b67b-d9d4-457d-9b78-878a814cde6e",
+        "fd204bf4-66fb-4376-b05e-ce98c6098e03",
+        "a793b4d4-5f1a-4d3e-88a8-25db0dff9457",
+        "fd3506ea-a0c1-435a-9705-af5dbdb17400",
+        "b1ad6da4-3254-479f-8a21-339b2c17a5dc",
+        "de707ffb-3a19-48d7-8706-5f549f61ff7f"
+      ],
+      "locked": false,
+      "name": "hitbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HIT_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "1d0c358c-a271-4f8a-b1eb-2dd20bb12576",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "8830744a-3665-4a7a-ba59-57f5257c5a24",
+        "0ff04713-c8ee-4c22-a2a3-af2c511f8a18",
+        "2050513a-608f-445f-a976-1e6f8574b5cd",
+        "6acc9cea-cfdc-42e3-a9cf-a502fa85b709",
+        "e2c189cd-0ecb-4241-9242-a8c2452b49ee",
+        "4782e262-e201-45f3-8649-a827a13142ce",
+        "10489cca-01f1-4b78-bd16-d9c6182efeca",
+        "2f94c747-4ba1-4941-8293-73a39eb08cbc",
+        "bd4a870a-cec0-46ee-a446-ff6d5f583eb3",
+        "f76fddec-3605-4d93-9557-cfc3270706e7"
+      ],
+      "locked": false,
+      "name": "hurtbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "601c6a92-7d15-4c9f-b903-9c862ea0e194",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "bb042f6b-0050-47c1-88a0-e15b3bd6c985",
+        "f20697c1-8552-4ad8-8563-6f7ce1174c04",
+        "3e74b9ec-97dd-4f7d-8aca-b4ba217dee5c",
+        "00b79443-0d18-403a-8e0c-5f1eac8e3720",
+        "07306b8c-8ae3-4b7f-a66f-3728f3497f07",
+        "179c11e0-6f9d-4b24-bc82-1c5b5f0a1ccd",
+        "a56ebd03-e195-4970-a330-ec3060c64cd6",
+        "6f8e23f1-3d1b-4e8d-8712-f86a91db454b",
+        "3a539e1d-fffc-4aa0-8bf5-84b7aedc54ff",
+        "fa979022-1ac6-4d12-9f9f-7c5bc2606766"
+      ],
+      "locked": false,
+      "name": "hurtbox1",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 1
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "db326a84-763b-4581-beb8-0bebc016d747",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "501b4048-3a6b-4044-8ef9-b30e6f29f8c5",
+        "628ee882-25e9-4c00-b0d3-0b0965998453",
+        "528e5b43-01ce-4074-be92-fccf2890597a",
+        "cfe59698-994f-48ec-b7a0-1d8c05722dcf",
+        "deacb650-6b17-4e82-a294-e83be238d48c",
+        "5f806657-7bb2-46ed-9fd3-43d4834d9b32",
+        "c270d362-31c0-4264-9f0a-271752cba31e",
+        "0691f72e-fe54-4f22-825c-9a56d6b34d26",
+        "d7e032a8-c110-4338-92b4-2b859b6f57a2",
+        "b868d4de-59c0-40b5-a5df-864d3b7cd4bf"
+      ],
+      "locked": false,
+      "name": "hurtbox2",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 2
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "d5948371-752f-4936-abe9-30107e7b70b1",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xff00ff",
+      "hidden": false,
+      "keyframes": [
+        "f2ce1647-e218-4b8f-a6a1-02ce813ef4db",
+        "08874d02-b6be-478b-9bc8-76f4bf18b746",
+        "0860b8c2-e7f2-4c17-8e36-73fdda7a783d"
+      ],
+      "locked": false,
+      "name": "grabbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "GRAB_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "cb611241-3019-4951-9af3-99a0eb90f4fc",
+      "hidden": false,
+      "keyframes": [
+        "9bd6ed14-fa5f-40cb-8794-fe1efb035dd4",
+        "7bd7cea0-4564-4a03-90cc-0096f3299c5d",
+        "25871ec8-4030-4d0b-a443-bbf5a2525768"
+      ],
+      "locked": false,
+      "name": "grabholdpoint0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "pointType": "GRAB_HOLD_POINT"
+        }
+      },
+      "type": "POINT"
+    },
+    {
+      "$id": "12a81570-be69-4c26-bfac-85fa2f1b8bfa",
+      "hidden": false,
+      "keyframes": [
+        "fef82d5a-3246-48fc-b39c-69a7554c678c"
+      ],
+      "locked": false,
+      "name": "Image Layer",
+      "pluginMetadata": {
+      },
+      "type": "IMAGE"
+    },
+    {
+      "$id": "700dbf6a-611e-4611-9a94-8ee95f76c74e",
+      "hidden": false,
+      "keyframes": [
+        "bf788f2c-cf0e-430d-b499-e50bafae23c5",
+        "506d7ec2-9863-4449-a086-9d3c4921eacb"
+      ],
+      "language": "hscript",
+      "locked": false,
+      "name": "Frame Script Layer",
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "19dce852-ed02-41d4-a983-ee62fb04ed03",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xff0000",
+      "hidden": false,
+      "keyframes": [
+        "bb2e5f34-ba88-4f7c-ab96-79ca74a18052"
+      ],
+      "locked": false,
+      "name": "hitbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HIT_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "bbb50dec-76a3-405b-b24e-239deee4e8d7",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "d2208c9c-4860-4911-90b7-7e99e0200d9a"
+      ],
+      "locked": false,
+      "name": "hurtbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "db0a943f-f9bd-4e92-ab2c-c2f4190217c7",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "05d4a2d4-c388-4e30-99d7-be79ef7aa5bf"
+      ],
+      "locked": false,
+      "name": "hurtbox1",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 1
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "677a7f6c-88a0-4428-849f-a7dd1f6ba63c",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "69a26144-0d34-4868-9687-a66888017e9f"
+      ],
+      "locked": false,
+      "name": "hurtbox2",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 2
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "d931a31c-260f-4eef-a5bf-8dbd88d8bad9",
+      "hidden": false,
+      "keyframes": [
+        "6302ecfa-a95c-40b6-9934-8bed0be57c17",
+        "857674f3-4a1e-4fce-ab55-5b2edd68d98d",
+        "129fdd4d-4eb0-45a6-98e3-7a67d143c7d1",
+        "f6d1debe-9f7c-40ef-b8e1-1e97d8de1a5f",
+        "486983d1-d5c7-4c20-bcd8-85bb8d2ace48",
+        "cda88091-67f4-49c8-9089-4778f58a3e94",
+        "e95dff3c-31f4-4156-8c25-d69df922f406",
+        "a7e16582-7251-4adc-ba85-475cfc09eb1c",
+        "ed97162c-6a57-4836-885d-0aa5ef3cb7ce",
+        "032ebf54-a70b-43de-92e0-f7ff5db6e644"
+      ],
+      "locked": false,
+      "name": "Image Layer",
+      "pluginMetadata": {
+      },
+      "type": "IMAGE"
+    },
+    {
+      "$id": "40251165-5b6d-446b-beb1-9c696bba575e",
+      "hidden": false,
+      "keyframes": [
+        "c83afa69-cf79-46f3-8a6e-90d54ee8761c",
+        "c9486204-797e-4772-8d26-8e498e95f7ef",
+        "6bab9d94-ccb4-4744-b27e-1e75e07a99f7",
+        "8c4994f4-3b1f-4e0e-bf92-9fb65ada56b4"
+      ],
+      "language": "hscript",
+      "locked": false,
+      "name": "Frame Script Layer",
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "7fa6145f-d40f-4b2b-941f-1588d4b7c81b",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xff0000",
+      "hidden": false,
+      "keyframes": [
+        "6bfa043e-83ba-4b06-a529-7bffbaf8d2c6",
+        "29434f8a-2287-416f-8548-61cbdd83ba07",
+        "c1207acf-e0f2-4e4c-b28c-4f428d936e52",
+        "07c42286-86cd-4948-950f-488dfad54fc7",
+        "ab32d42f-7c0e-48a2-ba89-7a76fe2b9d49",
+        "0fd5d17c-ccf0-4532-a73a-947cfab051fb",
+        "30810c91-9fbb-4014-a404-5f887bb05215",
+        "ef421623-7937-47a8-bfac-dc2aa9f281ff",
+        "061fb687-a287-402f-88a2-b02dfcbcec37",
+        "273a7055-ddf6-4e5e-a241-a599064e5967"
+      ],
+      "locked": false,
+      "name": "hitbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HIT_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "b030b373-77a2-4685-9af5-0e1b77e3111c",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "c3ac0fa1-3b42-4c92-a5ee-ea5a388c7b6f",
+        "d19bc98a-91d5-437a-ac88-8b89c84f1fec",
+        "1da211bc-4931-4522-8e98-dfb514b47853",
+        "78370598-bf6f-4a0a-88ee-40ca1a0ceae4",
+        "ebc6a1e0-f5b6-4431-9db3-19668b14e17e",
+        "d06dd064-5ece-4ada-8f93-d623100c53f1",
+        "651b7afa-b2f9-48cf-b658-1cdff5be325d",
+        "ea359c51-c03a-49a4-9a5c-210243a9a5be",
+        "ac10267c-0268-4f4e-9bf3-40ff2b3bddad",
+        "5a96e944-6dab-42ea-9f48-771109dd8b27"
+      ],
+      "locked": false,
+      "name": "hurtbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "56235a67-0692-4186-a04f-d4e4c7138bc6",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "ee23e587-5cef-46cf-af2d-b8d1176f052e",
+        "60e5b667-2ca6-42f5-818c-79c162c0af4a",
+        "7d0d8dac-3504-47df-a44a-cf3f162af14c",
+        "b98602de-34cf-4db7-924c-486fe4c106ee",
+        "aa0ca4ae-6ca3-41ec-aa66-1eb9f2c33d26",
+        "f1c59225-000c-4842-9da0-fb183b744474",
+        "636f0398-7b19-4519-bde5-081dda613658",
+        "701c5bdd-ffef-415e-8a5a-29e29e81743b",
+        "176000c5-eb98-441b-a598-e049699169ed",
+        "6509afd8-0f8a-4ca8-954d-adfe668239f2"
+      ],
+      "locked": false,
+      "name": "hurtbox1",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 1
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "e5e066e3-704a-4810-a0ea-6af1e2cd9ee8",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "1befff16-6ed5-49a8-be7c-32472d85ee43",
+        "08567461-7a0b-480c-ad40-3a170a64b685",
+        "6b7b29b5-f0f6-4300-a8b1-a180a281f096",
+        "e597f38b-5243-4cf1-8d3b-9d8e137690d1",
+        "54911e60-3d56-45b0-8a6c-0f0f3cc3ebf2",
+        "0b6b7163-663b-4f10-bf21-0eaed7cf2ae7",
+        "cab45102-af4c-4173-a05d-450c4e101ca3",
+        "4b7cfe46-29db-4df2-b98f-6b21cee37d8d",
+        "5cbd436b-8acb-40ff-a8ca-c8628bff5678",
+        "67e533fe-156c-495c-afa0-30c4dfe1adac"
+      ],
+      "locked": false,
+      "name": "hurtbox2",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 2
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "ebdb84b0-bd57-420a-9689-8a03bb2f6ccf",
+      "hidden": false,
+      "keyframes": [
+        "90262c6a-e56e-4b75-a8f3-d402ca789a80",
+        "46adbed8-b470-4c8b-8ca1-84ec2f0a4400",
+        "9621b72c-0408-4021-b96f-70e66e361918",
+        "92ef9d53-7a57-42bb-a484-b82a94d252b7",
+        "aedec2b8-c47d-4961-96bb-12426e7cd1df",
+        "95fcf100-ea68-4737-935c-9918ca81ab06",
+        "82b3b5b2-3155-4aad-8570-bcd537cf4199",
+        "10d0ca60-ea54-47e9-940d-ada5335f1e8d",
+        "24936b7f-97df-4ca9-bb5b-17630df9ecbc"
+      ],
+      "locked": false,
+      "name": "Image Layer",
+      "pluginMetadata": {
+      },
+      "type": "IMAGE"
+    },
+    {
+      "$id": "36b7c953-dc25-4da0-8de5-d4158aed5508",
+      "hidden": false,
+      "keyframes": [
+        "9741efa3-20d0-4b24-89e2-7e41597a87c8",
+        "8f5318bd-58e0-4581-a695-84b2acb79935",
+        "fd66f4ff-98a4-47c5-bd56-4531a6b649a2",
+        "f1d1f494-5bd3-4cdc-92ba-a24fcbfa9c3e"
+      ],
+      "language": "hscript",
+      "locked": false,
+      "name": "Frame Script Layer",
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "6588895b-71a0-42f1-8687-5c6da0599d44",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xff00ff",
+      "hidden": false,
+      "keyframes": [
+        "c75bb6ae-a074-468e-9971-c6204f42e299",
+        "e6973cb7-d691-42c1-87bc-2492cdac153e",
+        "812609fa-b704-483e-b9ae-e5d90b33c7ab"
+      ],
+      "locked": false,
+      "name": "grabbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "GRAB_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "7aed755e-4c90-44b1-91dc-e2fa4dfc0ab6",
+      "hidden": false,
+      "keyframes": [
+        "27965267-14ad-43e4-9cbd-193ba464423b",
+        "78e7e9b9-5d8f-4393-92b7-707b07e6b580",
+        "2eaa6483-0e0f-4759-a6d0-bd62b6277234"
+      ],
+      "locked": false,
+      "name": "grabholdpoint0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "pointType": "GRAB_HOLD_POINT"
+        }
+      },
+      "type": "POINT"
+    },
+    {
+      "$id": "662b184f-58ed-4b9c-9b31-a03d896b012f",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xff0000",
+      "hidden": false,
+      "keyframes": [
+        "0e60cbc6-68aa-4962-a711-a7381ff51242",
+        "3e8f93a6-1f54-4a9f-bc5b-9d2d3fd2aa3c",
+        "67ab96eb-a7c9-433d-b613-e841f4b62b6b",
+        "09effe79-a92c-451a-9fdc-825a70c3adde",
+        "117b1ccc-eaa6-4cf4-9db0-7fb7c2c0abb8",
+        "cbc81609-c933-45fb-b723-13d0c399fc68",
+        "d3d51252-2062-4b1b-bef9-e5636d62ad84",
+        "04a43931-820f-4427-baa1-1604e9b92525",
+        "c47975b2-5941-428d-b0e7-c83293101151"
+      ],
+      "locked": false,
+      "name": "hitbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HIT_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "48f2b8c6-a0d7-4e1b-85aa-a5338c549ef9",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "1cafed36-6bba-4ceb-bd8e-2632b44d6559",
+        "d15167b4-aadb-4b4c-b58d-c69bb8326840",
+        "3afc7df9-07dc-44e3-b88c-e741ac763da0",
+        "290d35b5-eacc-4408-abd2-ba264240bc2c",
+        "0b1aaa6e-7ca4-419f-840b-0947a9e86248",
+        "03f1e076-0f2d-4b0c-b793-8c3ca3cc33ed",
+        "b7bade6f-1d00-405e-b73d-0067e16b7433",
+        "0828424d-1e31-4f4e-b564-e76e282fc836",
+        "30669ac4-19cd-48f0-9d62-87696c0d3e29"
+      ],
+      "locked": false,
+      "name": "hurtbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "f1480963-268f-4ed2-a753-952f01153847",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "e4426f8f-af9c-4329-a3ad-66930a2f8d3d",
+        "4c396626-dac0-4fa3-a154-88785c91b7df",
+        "52532d65-8042-4d40-a629-64df365f263c",
+        "16c8c95c-9083-4b88-ac61-adefccf116c0",
+        "bbaf2405-f26d-4fb7-938e-486c02fb1f96",
+        "1f856e7d-ccde-438a-b549-348865e2a96d",
+        "503469f5-f93b-4a63-9e2f-a5ac52ba29da",
+        "6116b323-44e7-4811-b683-786726cdab94",
+        "dbc77ce0-58d2-4f10-9059-5d4b6235dd22"
+      ],
+      "locked": false,
+      "name": "hurtbox1",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 1
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "e51f5f31-53b3-41e7-a4bb-54ca045e8c96",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "47124092-a5b3-4fd1-8c21-a1aaabdbe9cf",
+        "228bc995-11a9-49b7-bd74-90d599d4355e",
+        "f9e522ec-d8bf-4d47-b9e5-6b6d2a62cf64",
+        "015736d8-eaff-4441-a4ba-f3d246ac9129",
+        "088eef7e-81c8-4dec-ac0a-413ccc941678",
+        "921b682e-8802-4e35-896d-25c3769da2f3",
+        "c45d5618-93c0-4158-8555-fb8f3cb81210",
+        "461103d8-b66c-4243-817c-1b9fecb73ece",
+        "bad58692-b695-44c9-83d2-f347ed08ce73"
+      ],
+      "locked": false,
+      "name": "hurtbox2",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 2
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "35432f90-c09f-43ce-b894-9f826db7f48f",
+      "hidden": false,
+      "keyframes": [
+        "95743d91-a0fc-4b7f-8e0a-fbab9082a23b",
+        "7899227e-93ce-412c-b5db-d0307428a711",
+        "b01ce571-5b51-434e-bea3-9842fb6bef6e",
+        "9922e266-bc95-4cf6-bd95-e263bfd999e7",
+        "8318f215-4fff-4251-9dad-b430903726da",
+        "1798a013-8281-4e72-a268-67b1bb30f519",
+        "7e605f55-05a4-4f3e-8ca2-9a908aaf32a2",
+        "2080c435-4960-4fdc-b086-bc4a65a2be7a",
+        "2591c2a0-9f92-4e4e-9f05-071cca083b46"
+      ],
+      "locked": false,
+      "name": "Image Layer",
+      "pluginMetadata": {
+      },
+      "type": "IMAGE"
+    },
+    {
+      "$id": "2bd1f54d-5bbd-4b94-af26-2f461507d4f1",
+      "hidden": false,
+      "keyframes": [
+        "bf22fc2d-65c7-4f69-8932-72bdee6cb40c",
+        "49abeeaa-8ebf-4a1a-9b2c-865742c0232e",
+        "bf5ad2cd-107b-434c-9a93-432b4a1f1c03",
+        "0c919a96-7ae4-42d2-962a-ae7273fd386e"
+      ],
+      "language": "hscript",
+      "locked": false,
+      "name": "Frame Script Layer",
+      "pluginMetadata": {
+      },
+      "type": "FRAME_SCRIPT"
+    },
+    {
+      "$id": "c6804fff-1814-4db5-9594-12935f8609e8",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xff0000",
+      "hidden": false,
+      "keyframes": [
+        "2d39611f-a63c-4a10-b7d6-4eac7085ad9f",
+        "6c5740dc-cea5-4ab0-872a-e366fc99b18d",
+        "8e17d3b9-eb33-4f82-a9ea-974bcd597d08",
+        "63db6c70-d7c0-48fb-9235-88022679a5db",
+        "913ba1df-7b1e-4dcb-b856-81712e6e336a",
+        "7bbed9d6-d742-4dad-80b8-77f3fc602418",
+        "8804528f-e8d3-4d0e-8543-898f5e620a02",
+        "e631131f-079f-48d4-96dd-1a9e1c8af67d",
+        "ce86aa04-f3d7-4030-9936-16ad20331209"
+      ],
+      "locked": false,
+      "name": "hitbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HIT_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "20079a30-64cf-43a4-a2f6-fedbb329006b",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "28355437-102d-42fa-af0b-4bdf5ad67ff5",
+        "37f505af-5f81-443b-8f3d-726f10c6ab89",
+        "41272ba2-aa79-4249-a874-bdc69686867a",
+        "b067dd07-932f-4ffa-8131-3f2353f0abb1",
+        "e5b6fe1e-569f-4792-a926-2746163ff972",
+        "b6ff9ddf-889e-47b8-b28f-9fd919cbdc26",
+        "1a325b28-6eb5-42c9-9732-ce58414fc121",
+        "5e09755c-be84-436b-90a0-b014701efdf5",
+        "7d0c96f2-278f-42b4-bb5f-0ef1025bbc0b"
+      ],
+      "locked": false,
+      "name": "hurtbox0",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 0
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "030aa8ba-0e6c-4ff4-b4e4-77317627fd44",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "93be23b2-eacf-475b-9335-444d5d72bead",
+        "c8077ee6-a1a4-4a81-aaa2-d9bb870b852e",
+        "52f75a68-5d7c-4d57-93e3-8e72a7e34dcf",
+        "a8a92787-c93c-49c7-ae67-46f8e2bb8dc0",
+        "05d5804c-d035-4126-91fc-910c960fa1d2",
+        "647f15fe-bb5f-45fa-9730-e733533616a3",
+        "d56ac7c6-4e12-43f8-823d-d9b433d1e165",
+        "f373fd6a-5cbb-4cb9-9c64-f5826002eb02",
+        "33bf9d44-e8d2-4c81-bb28-f65c02d54101"
+      ],
+      "locked": false,
+      "name": "hurtbox1",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 1
+        }
+      },
+      "type": "COLLISION_BOX"
+    },
+    {
+      "$id": "3d614683-4892-4675-bb02-bb2bdd2fa2a4",
+      "defaultAlpha": 0.5,
+      "defaultColor": "0xf5e042",
+      "hidden": false,
+      "keyframes": [
+        "ae0c6952-0bf1-49cb-8f00-e8129c100fff",
+        "a57d2841-a6b5-46e4-b62c-facdc6c6d4e4",
+        "01fedaa3-f032-4423-bd0e-47a703ed19a5",
+        "4c76e275-3c09-43b7-af48-478059b5ad38",
+        "c450ce55-b0ff-4a99-9608-cfc2051838c5",
+        "a42200d1-ba56-4a76-acab-1b08c95387a5",
+        "8ac7f9cc-31f0-491f-a614-d672d94c1cf0",
+        "35c5fbfa-0152-4152-a3de-2c88ff769f75",
+        "13886e99-4e73-4dd5-8b6d-d32f5dff138f"
+      ],
+      "locked": false,
+      "name": "hurtbox2",
+      "pluginMetadata": {
+        "com.fraymakers.FraymakersMetadata": {
+          "collisionBoxType": "HURT_BOX",
+          "index": 2
         }
       },
       "type": "COLLISION_BOX"
@@ -65138,456 +67929,6 @@
       "type": "COLLISION_BOX",
       "x": 14,
       "y": -69
-    },
-    {
-      "$id": "07c898a1-e4fe-4204-a8ab-8df46c378e93",
-      "alpha": 1,
-      "imageAsset": "b4c1a8d9-3eda-4131-8818-d2266b0ab240",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "7c45c3b1-a464-4864-bd9e-fd568717a4b5",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 40,
-      "scaleY": 55,
-      "type": "COLLISION_BOX",
-      "x": -11,
-      "y": -55
-    },
-    {
-      "$id": "6db07d7a-42ce-42b3-8574-453f19e3f6c1",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 16,
-      "type": "COLLISION_BOX",
-      "x": 14,
-      "y": -69
-    },
-    {
-      "$id": "d808bf7b-c577-4f54-8f83-6eac7a9dbe25",
-      "alpha": 1,
-      "imageAsset": "e0714dc2-6473-4bc7-aa44-1997ee8d2d75",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "8514e7c1-c8ab-4198-91d5-95cb307e2fe0",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 36,
-      "scaleY": 55,
-      "type": "COLLISION_BOX",
-      "x": 0,
-      "y": -55
-    },
-    {
-      "$id": "241b3a1f-d30d-4f66-8df4-514bc6065f48",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 16,
-      "type": "COLLISION_BOX",
-      "x": 14,
-      "y": -69
-    },
-    {
-      "$id": "b0272e15-4b0c-4e68-9a6e-3acbbc69c0ea",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 70,
-      "scaleY": 30,
-      "type": "COLLISION_BOX",
-      "x": -25,
-      "y": -30
-    },
-    {
-      "$id": "f76166bf-7ad4-48c0-a15a-8ac1bb9a46c8",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 17,
-      "scaleY": 37,
-      "type": "COLLISION_BOX",
-      "x": 19,
-      "y": -55
-    },
-    {
-      "$id": "1020dbf5-d87c-4cd0-874b-495086b36a36",
-      "alpha": 1,
-      "imageAsset": "ac60321f-7a61-4a4b-b7cb-976c0f83b57e",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "142bf58b-48e2-4568-92a4-f17a5b4d784a",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 46,
-      "scaleY": 76,
-      "type": "COLLISION_BOX",
-      "x": -12,
-      "y": -76
-    },
-    {
-      "$id": "cb758834-3b02-49a2-9a73-8e1c9e625854",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 15,
-      "type": "COLLISION_BOX",
-      "x": 9,
-      "y": -85
-    },
-    {
-      "$id": "221752d4-0241-45e0-b405-684b1265287d",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 30,
-      "scaleY": 54,
-      "type": "COLLISION_BOX",
-      "x": 4,
-      "y": -76
-    },
-    {
-      "$id": "b9519095-e1db-4b9a-99cd-fba2d7b43ac0",
-      "alpha": 1,
-      "imageAsset": "e8ff9c8a-3961-4bc8-8c6c-70d792e20950",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "40dd4651-4b1b-4748-9d9b-c0a0153d678a",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 42,
-      "scaleY": 76,
-      "type": "COLLISION_BOX",
-      "x": -14,
-      "y": -76
-    },
-    {
-      "$id": "8249a758-b441-4b14-a5a4-6837a9cb4553",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 15,
-      "type": "COLLISION_BOX",
-      "x": 7,
-      "y": -85
-    },
-    {
-      "$id": "44297bd2-72d4-4d5c-a92c-f17e1513136d",
-      "alpha": 1,
-      "imageAsset": "1f7ae81b-eab4-4877-acae-52fe407873c0",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "121b5a0f-9e35-4039-8e7a-82d240de444e",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 42,
-      "scaleY": 76,
-      "type": "COLLISION_BOX",
-      "x": -14,
-      "y": -76
-    },
-    {
-      "$id": "e16fdb40-d141-4208-b804-df02ab61d2c4",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 15,
-      "type": "COLLISION_BOX",
-      "x": 7,
-      "y": -85
-    },
-    {
-      "$id": "8ee75c68-45e4-439f-ab50-fd3c4a37eac1",
-      "alpha": 1,
-      "imageAsset": "e8ff9c8a-3961-4bc8-8c6c-70d792e20950",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "773065b8-0248-4a33-9d90-14e06f09a427",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 42,
-      "scaleY": 76,
-      "type": "COLLISION_BOX",
-      "x": -14,
-      "y": -76
-    },
-    {
-      "$id": "55414dc0-0f0d-44e9-80cc-5d22aa2dfcdf",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 15,
-      "type": "COLLISION_BOX",
-      "x": 7,
-      "y": -85
-    },
-    {
-      "$id": "3aa208b0-d3af-4b4c-9e52-ea531e6dcc5c",
-      "alpha": 1,
-      "imageAsset": "1f7ae81b-eab4-4877-acae-52fe407873c0",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "d2e6b53d-d48a-428b-822f-b5acaaa27ae0",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 42,
-      "scaleY": 76,
-      "type": "COLLISION_BOX",
-      "x": -14,
-      "y": -76
-    },
-    {
-      "$id": "16870f16-ab60-4640-abd7-ac1cb5860f62",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 15,
-      "type": "COLLISION_BOX",
-      "x": 7,
-      "y": -85
-    },
-    {
-      "$id": "d3007015-60bc-4d4e-8863-3ffed11b0993",
-      "alpha": 1,
-      "imageAsset": "0be03511-2404-4516-aa87-156e06224d57",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "67267041-2091-41f6-858b-880ccb5e7cfa",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 42,
-      "scaleY": 76,
-      "type": "COLLISION_BOX",
-      "x": -14,
-      "y": -76
-    },
-    {
-      "$id": "94d38728-69ee-4496-8cc1-39d66b2062b2",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 15,
-      "type": "COLLISION_BOX",
-      "x": 7,
-      "y": -85
-    },
-    {
-      "$id": "2614fd93-8d75-4cd4-bfee-04ab7ed7baaa",
-      "alpha": 1,
-      "imageAsset": "85958c1d-e263-499b-aa84-032a65d65d8e",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "3937d578-c87f-4f24-bc42-cead0b498bf0",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 29,
-      "scaleY": 80,
-      "type": "COLLISION_BOX",
-      "x": -10,
-      "y": -80
-    },
-    {
-      "$id": "635050f9-bdcd-4e88-97ea-0c49edc0310a",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 12,
-      "scaleY": 14,
-      "type": "COLLISION_BOX",
-      "x": 0,
-      "y": -94
     },
     {
       "$id": "41e2594f-200e-4847-bb0b-b44ccc00f5cc",
@@ -81811,171 +84152,6 @@
       "y": -139
     },
     {
-      "$id": "ed2886b2-3d5e-4004-a3c2-29d257fea00d",
-      "alpha": 1,
-      "imageAsset": "b4c1a8d9-3eda-4131-8818-d2266b0ab240",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "63123f2b-762a-467d-a3df-b02efb3e759e",
-      "alpha": 1,
-      "imageAsset": "e0714dc2-6473-4bc7-aa44-1997ee8d2d75",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "67a501ef-4c1e-4678-a1fd-0645998f7ef7",
-      "alpha": 1,
-      "imageAsset": "ac60321f-7a61-4a4b-b7cb-976c0f83b57e",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "6ba7c10f-86a5-44d7-bc2d-2ea9268f88b3",
-      "alpha": 1,
-      "imageAsset": "e8ff9c8a-3961-4bc8-8c6c-70d792e20950",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "0ac18ada-581c-45ac-9e35-6fa564060f14",
-      "alpha": 1,
-      "imageAsset": "1f7ae81b-eab4-4877-acae-52fe407873c0",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "16b64a6e-a960-420e-99c4-6c039a16f20e",
-      "alpha": 1,
-      "imageAsset": "e8ff9c8a-3961-4bc8-8c6c-70d792e20950",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "43614c1a-e86a-4faf-ae06-29a56a6f0839",
-      "alpha": 1,
-      "imageAsset": "1f7ae81b-eab4-4877-acae-52fe407873c0",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "9c720538-31d9-4cf2-8d04-1dcaed71dae8",
-      "alpha": 1,
-      "imageAsset": "0be03511-2404-4516-aa87-156e06224d57",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "57105572-810f-45bf-9595-9757a4c05184",
-      "alpha": 1,
-      "imageAsset": "85958c1d-e263-499b-aa84-032a65d65d8e",
-      "pivotX": 400,
-      "pivotY": 400,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 1,
-      "scaleY": 1,
-      "type": "IMAGE",
-      "x": -91,
-      "y": -139
-    },
-    {
-      "$id": "c51daa98-6a08-4053-ac0a-f8fd35be1fcd",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 17,
-      "scaleY": 37,
-      "type": "COLLISION_BOX",
-      "x": 19,
-      "y": -55
-    },
-    {
-      "$id": "c0c8bdc4-1be6-416e-9bf0-af3fed18b8c0",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 30,
-      "scaleY": 54,
-      "type": "COLLISION_BOX",
-      "x": 4,
-      "y": -76
-    },
-    {
       "$id": "e8c4fb78-f2fc-41f3-98d4-0fa28c1747dd",
       "alpha": null,
       "color": null,
@@ -81991,141 +84167,6 @@
       "y": -55
     },
     {
-      "$id": "3bcef01a-f4dd-4310-a529-0be9b0b0e251",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 40,
-      "scaleY": 55,
-      "type": "COLLISION_BOX",
-      "x": -11,
-      "y": -55
-    },
-    {
-      "$id": "301d8c79-3418-4ec6-a316-f2eb6beb50d3",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 36,
-      "scaleY": 55,
-      "type": "COLLISION_BOX",
-      "x": 0,
-      "y": -55
-    },
-    {
-      "$id": "ddcc30bf-809d-4c1b-abec-a94ff0c63ab2",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 46,
-      "scaleY": 76,
-      "type": "COLLISION_BOX",
-      "x": -12,
-      "y": -76
-    },
-    {
-      "$id": "eb202f6c-9a7e-4540-ab4a-cde08c124906",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 42,
-      "scaleY": 76,
-      "type": "COLLISION_BOX",
-      "x": -14,
-      "y": -76
-    },
-    {
-      "$id": "fb17e06a-f88f-4e02-b6f9-1c057440931b",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 42,
-      "scaleY": 76,
-      "type": "COLLISION_BOX",
-      "x": -14,
-      "y": -76
-    },
-    {
-      "$id": "97d6bd58-5067-45d6-ad95-8f0add8fe41a",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 42,
-      "scaleY": 76,
-      "type": "COLLISION_BOX",
-      "x": -14,
-      "y": -76
-    },
-    {
-      "$id": "0c8ac6f0-d8be-4115-8709-042efa75752c",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 42,
-      "scaleY": 76,
-      "type": "COLLISION_BOX",
-      "x": -14,
-      "y": -76
-    },
-    {
-      "$id": "709e2ea7-946b-44c3-9a80-9e6fc0adf4ec",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 42,
-      "scaleY": 76,
-      "type": "COLLISION_BOX",
-      "x": -14,
-      "y": -76
-    },
-    {
-      "$id": "a10017d6-34d5-42ef-b9c2-11861986d025",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 29,
-      "scaleY": 80,
-      "type": "COLLISION_BOX",
-      "x": -10,
-      "y": -80
-    },
-    {
       "$id": "3ec5ed8a-28eb-456a-9351-6a1889fa0bca",
       "alpha": null,
       "color": null,
@@ -82139,156 +84180,6 @@
       "type": "COLLISION_BOX",
       "x": 14,
       "y": -69
-    },
-    {
-      "$id": "ae2fa9e5-6cd2-41fa-8bf3-b7506a53d122",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 16,
-      "type": "COLLISION_BOX",
-      "x": 14,
-      "y": -69
-    },
-    {
-      "$id": "9d367251-7b5a-44a1-9c33-325136f22d60",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 16,
-      "type": "COLLISION_BOX",
-      "x": 14,
-      "y": -69
-    },
-    {
-      "$id": "9d8c09f2-8697-417f-ab46-ebf5447ebd50",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 15,
-      "type": "COLLISION_BOX",
-      "x": 9,
-      "y": -85
-    },
-    {
-      "$id": "8919506c-48b5-47aa-b827-be96ae1fc7d8",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 15,
-      "type": "COLLISION_BOX",
-      "x": 7,
-      "y": -85
-    },
-    {
-      "$id": "a4859db1-3762-4a35-a60b-40e24b5c3301",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 15,
-      "type": "COLLISION_BOX",
-      "x": 7,
-      "y": -85
-    },
-    {
-      "$id": "f062492a-e293-4b0f-bcbe-b66f906d5ca1",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 15,
-      "type": "COLLISION_BOX",
-      "x": 7,
-      "y": -85
-    },
-    {
-      "$id": "3f90a932-f108-464b-95d3-132353187c9a",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 15,
-      "type": "COLLISION_BOX",
-      "x": 7,
-      "y": -85
-    },
-    {
-      "$id": "73165140-c3a7-4b5f-9631-9d3f11ffb11f",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 14,
-      "scaleY": 15,
-      "type": "COLLISION_BOX",
-      "x": 7,
-      "y": -85
-    },
-    {
-      "$id": "67b23f82-813d-47ee-a50b-dde9827a2fe5",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 12,
-      "scaleY": 14,
-      "type": "COLLISION_BOX",
-      "x": 0,
-      "y": -94
-    },
-    {
-      "$id": "d90ad6ec-b778-40ae-ad66-6037e916649e",
-      "alpha": null,
-      "color": null,
-      "pivotX": 0,
-      "pivotY": 0,
-      "pluginMetadata": {
-      },
-      "rotation": 0,
-      "scaleX": 70,
-      "scaleY": 30,
-      "type": "COLLISION_BOX",
-      "x": -25,
-      "y": -30
     },
     {
       "$id": "65557f09-9049-4fcd-8e01-c291692837bc",
@@ -90290,6 +92181,2443 @@
       "type": "COLLISION_BOX",
       "x": 1,
       "y": -71
+    },
+    {
+      "$id": "7ddfbce4-8bc2-4271-a459-bda2c4bd99a0",
+      "alpha": 1,
+      "imageAsset": "6d962a9a-bf78-4e6a-a8e1-58e7089b9494",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "75fdebe7-114d-49e0-9a12-7f3edbe8d456",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 40,
+      "scaleY": 55,
+      "type": "COLLISION_BOX",
+      "x": -11,
+      "y": -55
+    },
+    {
+      "$id": "84680f8b-cac5-40e7-8c1f-32d7b46ba33b",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 16,
+      "type": "COLLISION_BOX",
+      "x": 14,
+      "y": -69
+    },
+    {
+      "$id": "6218077b-21d7-4243-be7c-cf2dfd618887",
+      "alpha": 1,
+      "imageAsset": "b4c1a8d9-3eda-4131-8818-d2266b0ab240",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "d3493676-667a-4924-a10b-129ae92637c4",
+      "alpha": 1,
+      "imageAsset": "e0714dc2-6473-4bc7-aa44-1997ee8d2d75",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "ede556c2-1e47-4695-8610-8f573326c628",
+      "alpha": 1,
+      "imageAsset": "ac60321f-7a61-4a4b-b7cb-976c0f83b57e",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "3e62f543-3968-42ef-83b5-75166acdd228",
+      "alpha": 1,
+      "imageAsset": "e8ff9c8a-3961-4bc8-8c6c-70d792e20950",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "ab8b9cf0-3d1e-45ec-83f1-4b636cea0bd0",
+      "alpha": 1,
+      "imageAsset": "1f7ae81b-eab4-4877-acae-52fe407873c0",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "769d9bd6-579f-459e-9112-e33ef7876c0d",
+      "alpha": 1,
+      "imageAsset": "e8ff9c8a-3961-4bc8-8c6c-70d792e20950",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "e1abf7a7-7340-4678-9998-993bc37d360b",
+      "alpha": 1,
+      "imageAsset": "1f7ae81b-eab4-4877-acae-52fe407873c0",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "4931cfbf-38f9-4c08-ab2c-fdcb6fb0c182",
+      "alpha": 1,
+      "imageAsset": "0be03511-2404-4516-aa87-156e06224d57",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "3c975ce0-7a5b-4d30-8756-29eb618ba3a9",
+      "alpha": 1,
+      "imageAsset": "85958c1d-e263-499b-aa84-032a65d65d8e",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "0b73155f-2b4c-4155-bf85-8369d915b607",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 30,
+      "scaleY": 54,
+      "type": "COLLISION_BOX",
+      "x": 4,
+      "y": -76
+    },
+    {
+      "$id": "3d244181-337f-4785-b6ba-8c35d9b9dfc3",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 40,
+      "scaleY": 55,
+      "type": "COLLISION_BOX",
+      "x": -11,
+      "y": -55
+    },
+    {
+      "$id": "d9ae9670-0780-4c1d-849b-b802e75040ff",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 36,
+      "scaleY": 55,
+      "type": "COLLISION_BOX",
+      "x": 0,
+      "y": -55
+    },
+    {
+      "$id": "f75cc14d-353a-4b6e-ac4a-8afb2511c1ee",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 46,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -12,
+      "y": -76
+    },
+    {
+      "$id": "7f7b8cee-03b1-49b6-8cb2-f9cd104900ac",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "b3f72c7d-74ba-477b-bc01-35b93348d7b2",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "e027e34f-c0e0-4bfa-ab32-a0bd401b9053",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "0b910fd8-8773-47a3-aa0e-6af174c512de",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "0a68d176-df60-48e0-a0c0-1c086bad3877",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "b6d628af-d135-4b0b-8c57-7ec08d0813fa",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 29,
+      "scaleY": 80,
+      "type": "COLLISION_BOX",
+      "x": -10,
+      "y": -80
+    },
+    {
+      "$id": "d0e08fc5-4bae-48dc-a78e-0d5f503ecc29",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 16,
+      "type": "COLLISION_BOX",
+      "x": 14,
+      "y": -69
+    },
+    {
+      "$id": "9333c7e5-374b-47cf-9a4b-a9064fb9b8d9",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 16,
+      "type": "COLLISION_BOX",
+      "x": 14,
+      "y": -69
+    },
+    {
+      "$id": "ab3c4d7b-e2b5-4c9b-adb3-0ff2df46be68",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 9,
+      "y": -85
+    },
+    {
+      "$id": "3e7ef108-c5a1-4f94-b764-c70449a2699d",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "b8f31e99-ef59-4adb-a081-eac9d94bfb36",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "ae2d8409-4397-4306-aede-be06a2f2701f",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "9ecee129-b0df-424a-a3f9-15e988194f33",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "51826d55-2ead-4328-b096-0bb91bf2cccd",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "f5e4c44e-5c10-4977-b7ec-618a63be8239",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 12,
+      "scaleY": 14,
+      "type": "COLLISION_BOX",
+      "x": 0,
+      "y": -94
+    },
+    {
+      "$id": "aa69ac48-8c60-4a3f-a18f-35ae256532ad",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 70,
+      "scaleY": 30,
+      "type": "COLLISION_BOX",
+      "x": -25,
+      "y": -30
+    },
+    {
+      "$id": "734ecd28-f4be-43c3-ac37-697c4fe96357",
+      "alpha": 1,
+      "imageAsset": "6d962a9a-bf78-4e6a-a8e1-58e7089b9494",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "67e38b39-679f-4a5e-98f1-b01c8af85c38",
+      "alpha": 1,
+      "imageAsset": "b4c1a8d9-3eda-4131-8818-d2266b0ab240",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "4a2bc0f4-895a-47ff-9d57-e43dffb3c827",
+      "alpha": 1,
+      "imageAsset": "e0714dc2-6473-4bc7-aa44-1997ee8d2d75",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "352da777-dbe7-4084-a56b-0c2a73974d0e",
+      "alpha": 1,
+      "imageAsset": "ac60321f-7a61-4a4b-b7cb-976c0f83b57e",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "109c1a75-cbc1-4846-9e13-c4c79fabab46",
+      "alpha": 1,
+      "imageAsset": "e8ff9c8a-3961-4bc8-8c6c-70d792e20950",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "ebb0ce1b-130e-4aa6-9375-bfa7a6886581",
+      "alpha": 1,
+      "imageAsset": "1f7ae81b-eab4-4877-acae-52fe407873c0",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "ee507176-252d-483f-97ef-548de6f24f53",
+      "alpha": 1,
+      "imageAsset": "e8ff9c8a-3961-4bc8-8c6c-70d792e20950",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "33e2543b-452b-4423-b9bf-2402a2656159",
+      "alpha": 1,
+      "imageAsset": "1f7ae81b-eab4-4877-acae-52fe407873c0",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "5c9bfc32-8c24-459f-bb5b-5616565cb18f",
+      "alpha": 1,
+      "imageAsset": "0be03511-2404-4516-aa87-156e06224d57",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "f49fdf87-7b43-4bc8-8c14-c1aae2a5229c",
+      "alpha": 1,
+      "imageAsset": "85958c1d-e263-499b-aa84-032a65d65d8e",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "6771b8ba-f3a4-43cc-be87-abeb65788d56",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 17,
+      "scaleY": 37,
+      "type": "COLLISION_BOX",
+      "x": 19,
+      "y": -55
+    },
+    {
+      "$id": "d583dff7-af44-4d55-a4eb-a4661042d623",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 30,
+      "scaleY": 54,
+      "type": "COLLISION_BOX",
+      "x": 4,
+      "y": -76
+    },
+    {
+      "$id": "aead5f6a-ba5d-4ded-900c-73ab3be0a6aa",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 40,
+      "scaleY": 55,
+      "type": "COLLISION_BOX",
+      "x": -11,
+      "y": -55
+    },
+    {
+      "$id": "2dbc6e7f-e7c2-4e59-8343-6e1d566d9269",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 40,
+      "scaleY": 55,
+      "type": "COLLISION_BOX",
+      "x": -11,
+      "y": -55
+    },
+    {
+      "$id": "a3cd3184-4e3c-4ff3-b983-017d4d78f7f0",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 36,
+      "scaleY": 55,
+      "type": "COLLISION_BOX",
+      "x": 0,
+      "y": -55
+    },
+    {
+      "$id": "d561a09c-e8f8-4179-8488-7a4f85527375",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 46,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -12,
+      "y": -76
+    },
+    {
+      "$id": "f50de00a-715e-4d81-ac2b-ef045592d0cb",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "c6c84fee-cd4d-469b-922f-aafc5bf3601b",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "47ba628e-4f9f-49c0-914a-d525bd94b6c7",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "4c371108-66ef-4e42-a986-c286f33b036d",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "81e5df2f-3a75-4778-8a69-325dc0ac0798",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "5f5d1914-37ef-468a-a626-9f94ec03058c",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 29,
+      "scaleY": 80,
+      "type": "COLLISION_BOX",
+      "x": -10,
+      "y": -80
+    },
+    {
+      "$id": "e92432fc-7860-480f-b1b9-bded83e70f47",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 16,
+      "type": "COLLISION_BOX",
+      "x": 14,
+      "y": -69
+    },
+    {
+      "$id": "d321a9f8-740f-492e-a6b7-7307f804725c",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 16,
+      "type": "COLLISION_BOX",
+      "x": 14,
+      "y": -69
+    },
+    {
+      "$id": "32185e7d-efda-416f-b2d3-9406c15cc9a1",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 16,
+      "type": "COLLISION_BOX",
+      "x": 14,
+      "y": -69
+    },
+    {
+      "$id": "d829f9df-c220-4c10-b0d9-aa87a5a12b50",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 9,
+      "y": -85
+    },
+    {
+      "$id": "5e8f5e00-2fc8-4ea0-8316-b2cb147587b6",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "5f89421d-93f1-4a53-9155-420b638b230a",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "769b7acc-0785-4509-a73b-3a66f1c9c87b",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "6b2582c6-1c23-4fdf-9e03-59ec2cc05339",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "80d75919-4b91-46ee-83c8-fe96ddae18c4",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "da785d6b-7ab4-4c06-b80f-27d00b1b8159",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 12,
+      "scaleY": 14,
+      "type": "COLLISION_BOX",
+      "x": 0,
+      "y": -94
+    },
+    {
+      "$id": "5d096ade-4ab2-402d-833d-dd72b8aff669",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 70,
+      "scaleY": 30,
+      "type": "COLLISION_BOX",
+      "x": -25,
+      "y": -30
+    },
+    {
+      "$id": "a00379b4-1be3-4864-9b24-1151b50e2c2c",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 17,
+      "scaleY": 37,
+      "type": "COLLISION_BOX",
+      "x": 19,
+      "y": -55
+    },
+    {
+      "$id": "60ffeed3-12da-459f-9f58-6443379a6563",
+      "alpha": 1,
+      "color": "0xff0000",
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "type": "POINT",
+      "x": 40,
+      "y": 0
+    },
+    {
+      "$id": "cd298235-0c60-4f22-a49c-b85bc480c91f",
+      "alpha": 1,
+      "imageAsset": "6d962a9a-bf78-4e6a-a8e1-58e7089b9494",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "72470018-6cab-4e08-bb3c-9f78b5c43aab",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 40,
+      "scaleY": 55,
+      "type": "COLLISION_BOX",
+      "x": -11,
+      "y": -55
+    },
+    {
+      "$id": "c6b84e6b-b56e-41d0-aa15-9e208b2c25b2",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 16,
+      "type": "COLLISION_BOX",
+      "x": 14,
+      "y": -69
+    },
+    {
+      "$id": "6970d19e-06d6-46b9-954a-0f1d6a1f9c4a",
+      "alpha": 1,
+      "imageAsset": "6d962a9a-bf78-4e6a-a8e1-58e7089b9494",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "f5e6ba99-8df4-4a4d-9bf8-93dc9db9a7ec",
+      "alpha": 1,
+      "imageAsset": "b4c1a8d9-3eda-4131-8818-d2266b0ab240",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "1d0512e0-5345-4f53-a391-5208a62860f0",
+      "alpha": 1,
+      "imageAsset": "e0714dc2-6473-4bc7-aa44-1997ee8d2d75",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "ed699834-5613-4b5d-8b1b-b55cd73f8f68",
+      "alpha": 1,
+      "imageAsset": "ac60321f-7a61-4a4b-b7cb-976c0f83b57e",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "b2eb3c68-1d96-44d9-acb8-86eabe73b731",
+      "alpha": 1,
+      "imageAsset": "e8ff9c8a-3961-4bc8-8c6c-70d792e20950",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "d16b0ec7-bdb3-4538-8e93-5ea93d0bd9ed",
+      "alpha": 1,
+      "imageAsset": "1f7ae81b-eab4-4877-acae-52fe407873c0",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "c2463073-933c-4152-8209-bbfa3bbb1ce1",
+      "alpha": 1,
+      "imageAsset": "e8ff9c8a-3961-4bc8-8c6c-70d792e20950",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "15341bd5-da45-45b0-8964-868cdc64f3e9",
+      "alpha": 1,
+      "imageAsset": "1f7ae81b-eab4-4877-acae-52fe407873c0",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "9abfee64-0921-4cab-a95e-2a7a50ed961f",
+      "alpha": 1,
+      "imageAsset": "0be03511-2404-4516-aa87-156e06224d57",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "f0831363-3d39-4163-85ad-60022fd8b3f8",
+      "alpha": 1,
+      "imageAsset": "85958c1d-e263-499b-aa84-032a65d65d8e",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "68ed4bb5-8e7e-42d7-89e2-cc67fe66863e",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 17,
+      "scaleY": 37,
+      "type": "COLLISION_BOX",
+      "x": 19,
+      "y": -55
+    },
+    {
+      "$id": "08cfeba3-9b33-43ed-a03b-5d82592d91f9",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 30,
+      "scaleY": 54,
+      "type": "COLLISION_BOX",
+      "x": 4,
+      "y": -76
+    },
+    {
+      "$id": "6e427413-0b6e-448c-8065-ea1a93b22ef4",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 40,
+      "scaleY": 55,
+      "type": "COLLISION_BOX",
+      "x": -11,
+      "y": -55
+    },
+    {
+      "$id": "1f38f281-0b2c-45a2-809e-297d661d4471",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 40,
+      "scaleY": 55,
+      "type": "COLLISION_BOX",
+      "x": -11,
+      "y": -55
+    },
+    {
+      "$id": "8cc22bc5-e8c4-4501-acce-06fac5313091",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 36,
+      "scaleY": 55,
+      "type": "COLLISION_BOX",
+      "x": 0,
+      "y": -55
+    },
+    {
+      "$id": "03abb5f0-2fb2-4ff2-8fe0-460292191f30",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 46,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -12,
+      "y": -76
+    },
+    {
+      "$id": "f0784442-f0f1-4d2a-9ee2-bb55a57bcda7",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "67b07ae6-8375-4810-9adc-0cc17bd14cb3",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "7c3755e3-7cd0-44f4-981c-75395785dea4",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "2e0e22e8-3be5-4f02-952e-f3ca57f7015b",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "ca73c1f6-20a4-48ef-a054-5f6ba5032805",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "b840702a-89f0-4c05-8cc0-c8c048d47406",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 29,
+      "scaleY": 80,
+      "type": "COLLISION_BOX",
+      "x": -10,
+      "y": -80
+    },
+    {
+      "$id": "3a539d95-54de-4dec-a952-a65cce3dbfab",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 16,
+      "type": "COLLISION_BOX",
+      "x": 14,
+      "y": -69
+    },
+    {
+      "$id": "b817e5d8-4727-4079-a02a-a0589e66980a",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 16,
+      "type": "COLLISION_BOX",
+      "x": 14,
+      "y": -69
+    },
+    {
+      "$id": "fe5aacaf-aa21-4095-91ca-fc9a99db49a3",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 16,
+      "type": "COLLISION_BOX",
+      "x": 14,
+      "y": -69
+    },
+    {
+      "$id": "e0c879cc-efa9-4754-bb33-afa119a73213",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 9,
+      "y": -85
+    },
+    {
+      "$id": "9112d092-635a-4bf6-bdab-1f3e467b49ee",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "ef84ba4b-b021-42c1-8ce2-6bc457d7be35",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "02d94454-8342-4cf9-bedc-b77864c2fb47",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "6f2d69e8-d65c-4782-b5a5-1bd7f1605a14",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "20e42e5a-18d7-41f5-b4a7-e46e12736c9f",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "9b67504e-97d6-47cf-bcab-5ebb1b8a9a97",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 12,
+      "scaleY": 14,
+      "type": "COLLISION_BOX",
+      "x": 0,
+      "y": -94
+    },
+    {
+      "$id": "ea391bfe-54a6-4dc1-9a6a-850071896c5f",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 70,
+      "scaleY": 30,
+      "type": "COLLISION_BOX",
+      "x": -25,
+      "y": -30
+    },
+    {
+      "$id": "7d45fd99-adcb-4a64-b5e8-40d2c55e9021",
+      "alpha": 1,
+      "imageAsset": "b4c1a8d9-3eda-4131-8818-d2266b0ab240",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "a03d49d1-978b-4cdf-8a1b-379ccbdcb710",
+      "alpha": 1,
+      "imageAsset": "e0714dc2-6473-4bc7-aa44-1997ee8d2d75",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "80f69c48-3f6c-4565-941f-ab3ca9991c13",
+      "alpha": 1,
+      "imageAsset": "ac60321f-7a61-4a4b-b7cb-976c0f83b57e",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "5e311d2d-ecca-441e-8338-888999139bbe",
+      "alpha": 1,
+      "imageAsset": "e8ff9c8a-3961-4bc8-8c6c-70d792e20950",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "b7f49f32-9cf8-4c3d-b81b-164f8d5eb1a3",
+      "alpha": 1,
+      "imageAsset": "1f7ae81b-eab4-4877-acae-52fe407873c0",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "6586f3cc-6c5a-41d8-8a6c-d1350afc7cb4",
+      "alpha": 1,
+      "imageAsset": "e8ff9c8a-3961-4bc8-8c6c-70d792e20950",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "1c9cb5cc-c2de-4f18-ba8b-aa6c3c0e7d21",
+      "alpha": 1,
+      "imageAsset": "1f7ae81b-eab4-4877-acae-52fe407873c0",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "9c60563e-413c-4cd8-80dc-59fce8969407",
+      "alpha": 1,
+      "imageAsset": "0be03511-2404-4516-aa87-156e06224d57",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "c4ead9ca-bc78-4699-8e53-3e9a568d61c3",
+      "alpha": 1,
+      "imageAsset": "85958c1d-e263-499b-aa84-032a65d65d8e",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "dd6280d4-0ade-45b9-857e-24c85cb5d8b6",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 17,
+      "scaleY": 37,
+      "type": "COLLISION_BOX",
+      "x": 19,
+      "y": -55
+    },
+    {
+      "$id": "2f977c8f-c8b1-4fc1-b54b-78df16df06d1",
+      "alpha": 1,
+      "color": "0xff0000",
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "type": "POINT",
+      "x": 40,
+      "y": 0
+    },
+    {
+      "$id": "fff8b0da-48e2-450a-998a-46efa8041bd5",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 30,
+      "scaleY": 54,
+      "type": "COLLISION_BOX",
+      "x": 4,
+      "y": -76
+    },
+    {
+      "$id": "3b7bf515-d876-413e-82ae-f8b4db307a09",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 40,
+      "scaleY": 55,
+      "type": "COLLISION_BOX",
+      "x": -11,
+      "y": -55
+    },
+    {
+      "$id": "18bea265-67e0-4622-9143-6e97f5d28451",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 36,
+      "scaleY": 55,
+      "type": "COLLISION_BOX",
+      "x": 0,
+      "y": -55
+    },
+    {
+      "$id": "2b5506f1-5337-46ad-b8c0-854625111b0b",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 46,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -12,
+      "y": -76
+    },
+    {
+      "$id": "c74ace8c-3b13-4b78-85ff-9536b0aafea3",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "c6fa297e-f971-412d-9d62-e30b12927809",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "bf275da9-d932-41c2-9652-91cfdb02c33f",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "12b54ada-b4cd-46dc-9c4b-98742e5ddd03",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "1a1fc8f3-e2b9-44d8-8f58-1ec9b2028905",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "24ab7202-bb3e-498d-9494-4eb0603a36a6",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 29,
+      "scaleY": 80,
+      "type": "COLLISION_BOX",
+      "x": -10,
+      "y": -80
+    },
+    {
+      "$id": "e8423a5f-d61f-49d7-af99-27e1719efd7a",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 16,
+      "type": "COLLISION_BOX",
+      "x": 14,
+      "y": -69
+    },
+    {
+      "$id": "7c5504d0-ea58-457c-930c-fd478e31d99a",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 16,
+      "type": "COLLISION_BOX",
+      "x": 14,
+      "y": -69
+    },
+    {
+      "$id": "da88b418-07c9-4ba6-b817-4e3750ef8e61",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 9,
+      "y": -85
+    },
+    {
+      "$id": "ee8212f7-ad98-4932-9079-1cc56f8ed00b",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "07f2ba3d-54f4-4a87-af84-78f4d0eaea3a",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "0fca7108-66c9-4f34-96b7-758e40b1ead9",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "7b137eac-0aff-4917-9b2f-9976c9061ffc",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "67704b35-576f-44fd-b921-d66603e72937",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "9a750016-fdcf-4ab9-bb0f-5e99d56b32d7",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 12,
+      "scaleY": 14,
+      "type": "COLLISION_BOX",
+      "x": 0,
+      "y": -94
+    },
+    {
+      "$id": "86dd6b66-5a73-475c-9ca0-be9f4052578a",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 70,
+      "scaleY": 30,
+      "type": "COLLISION_BOX",
+      "x": -25,
+      "y": -30
+    },
+    {
+      "$id": "04b32d97-56e4-427f-90ae-3757e1c3e31c",
+      "alpha": 1,
+      "imageAsset": "b4c1a8d9-3eda-4131-8818-d2266b0ab240",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "8a13c4bb-acb1-4adb-897a-d5e0868b7c18",
+      "alpha": 1,
+      "imageAsset": "e0714dc2-6473-4bc7-aa44-1997ee8d2d75",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "c7b70d0c-3a66-473f-920d-28d3e08199bb",
+      "alpha": 1,
+      "imageAsset": "ac60321f-7a61-4a4b-b7cb-976c0f83b57e",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "f74dff87-0266-4c4a-8a11-67aa88583978",
+      "alpha": 1,
+      "imageAsset": "e8ff9c8a-3961-4bc8-8c6c-70d792e20950",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "64e8684e-9029-41f7-b7b9-cae544b9e1f2",
+      "alpha": 1,
+      "imageAsset": "1f7ae81b-eab4-4877-acae-52fe407873c0",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "b111e866-80ba-4a83-bff2-0a0d58538d0b",
+      "alpha": 1,
+      "imageAsset": "e8ff9c8a-3961-4bc8-8c6c-70d792e20950",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "974465f1-eeb2-4200-a060-29e5c7110ae1",
+      "alpha": 1,
+      "imageAsset": "1f7ae81b-eab4-4877-acae-52fe407873c0",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "96107c2e-7f6b-4123-bc3f-083fa99dc995",
+      "alpha": 1,
+      "imageAsset": "0be03511-2404-4516-aa87-156e06224d57",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "c662237d-d9bb-4ef0-8688-485445cc6732",
+      "alpha": 1,
+      "imageAsset": "85958c1d-e263-499b-aa84-032a65d65d8e",
+      "pivotX": 400,
+      "pivotY": 400,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 1,
+      "scaleY": 1,
+      "type": "IMAGE",
+      "x": -91,
+      "y": -139
+    },
+    {
+      "$id": "2730eb3e-f8ca-4ee9-9a8b-c30f66dfa518",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 30,
+      "scaleY": 54,
+      "type": "COLLISION_BOX",
+      "x": 4,
+      "y": -76
+    },
+    {
+      "$id": "dd002905-cbd4-4c75-9009-dab93b773a6d",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 40,
+      "scaleY": 55,
+      "type": "COLLISION_BOX",
+      "x": -11,
+      "y": -55
+    },
+    {
+      "$id": "9c448209-b4dc-415f-bb11-b5e8a7693080",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 36,
+      "scaleY": 55,
+      "type": "COLLISION_BOX",
+      "x": 0,
+      "y": -55
+    },
+    {
+      "$id": "0c0919bb-c09c-4af8-8a9a-c954547da54d",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 46,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -12,
+      "y": -76
+    },
+    {
+      "$id": "ecbbd826-b3c3-4cde-b4a6-b28d373eb486",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "270df3c9-2225-4431-9ef0-463b1225bcb2",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "c35919ba-08b8-4ffe-91b7-765ba082afdf",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "273cf904-3068-43c0-9046-9a5610511333",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "456997e6-d424-4470-8d85-a2a24ce09ba8",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 42,
+      "scaleY": 76,
+      "type": "COLLISION_BOX",
+      "x": -14,
+      "y": -76
+    },
+    {
+      "$id": "31b0c769-2d24-4d3e-8592-1e2a0a0d6731",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 29,
+      "scaleY": 80,
+      "type": "COLLISION_BOX",
+      "x": -10,
+      "y": -80
+    },
+    {
+      "$id": "81073ce5-a0ae-4a9d-8285-5777806f77d6",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 16,
+      "type": "COLLISION_BOX",
+      "x": 14,
+      "y": -69
+    },
+    {
+      "$id": "5c5e3e71-2d65-4ad9-b863-d33df2d20730",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 16,
+      "type": "COLLISION_BOX",
+      "x": 14,
+      "y": -69
+    },
+    {
+      "$id": "f06767d6-f5ab-45c8-8375-5e2638870093",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 9,
+      "y": -85
+    },
+    {
+      "$id": "4350b0ad-710b-4d86-b2ec-971a7b601715",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "23dc3bc9-b253-4565-aab2-10deaebf9bbb",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "859ed466-ad66-45d0-aa3b-8650c0ec6786",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "c7903084-4165-4a23-9974-f28a95d0c7e1",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "eaee934e-9a70-4fcf-a092-e6af1cfe2012",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 14,
+      "scaleY": 15,
+      "type": "COLLISION_BOX",
+      "x": 7,
+      "y": -85
+    },
+    {
+      "$id": "8151c409-fff3-498e-b20a-f3ee26aee679",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 12,
+      "scaleY": 14,
+      "type": "COLLISION_BOX",
+      "x": 0,
+      "y": -94
+    },
+    {
+      "$id": "e985190f-265f-4ea7-9966-8960a6654448",
+      "alpha": null,
+      "color": null,
+      "pivotX": 0,
+      "pivotY": 0,
+      "pluginMetadata": {
+      },
+      "rotation": 0,
+      "scaleX": 70,
+      "scaleY": 30,
+      "type": "COLLISION_BOX",
+      "x": -25,
+      "y": -30
     }
   ],
   "tags": [

--- a/Kung Fu Man/library/scripts/Character/AnimationStats.hx
+++ b/Kung Fu Man/library/scripts/Character/AnimationStats.hx
@@ -94,8 +94,13 @@
 	special_up_air_kick: {allowMovement: true, nextState:CState.FALL_SPECIAL, landType:LandType.AUTO, landAnimation:"knee_land"}, 
 	special_side: {xSpeedConservation: 1.25},
 	special_side_air: {leaveGroundCancel:false, xSpeedConservation: 1, landType:LandType.LINK_FRAMES, landAnimation:"special_side"}, 
-	special_down: {allowTurnOnFirstFrame: true}, 
-	special_down_air: {allowFastFall:false, allowTurnOnFirstFrame: true, leaveGroundCancel:false, landType:LandType.LINK_FRAMES, landAnimation:"special_down"},
+	special_down: {allowMovement: false, allowTurnOnFirstFrame: true, nextAnimation: "special_down_loop"}, 
+	special_down_loop: {allowMovement: false, chargeFramesMax: 60, chargeGlow: true, chargeShake: true}, 
+	special_down_attack: {allowMovement: false}, 
+	special_down_air: {allowMovement: false, allowTurnOnFirstFrame: true, nextAnimation: "special_down_air_loop", landType:LandType.LINK_FRAMES, landAnimation:"special_down", gravityMultiplier: .1, singleUse:true}, 
+	special_down_air_loop: {allowMovement: false, chargeFramesMax: 60, chargeGlow: true, chargeShake: true, landType:LandType.LINK_FRAMES, landAnimation:"special_down_loop", gravityMultiplier: .1}, 
+	special_down_air_attack: {allowMovement: false, landType:LandType.LINK_FRAMES, landAnimation:"special_down_attack"},
+	special_down_clutch_attack: {allowMovement: false, slideOff: true},
 
 	//SUPERS
 	super1_freeze:  {allowTurnOnFirstFrame: false, allowMovement: false, endType:AnimationEndType.AUTO, nextAnimation:'super1',interruptible:false},

--- a/Kung Fu Man/library/scripts/Character/CharacterStats.hx.meta
+++ b/Kung Fu Man/library/scripts/Character/CharacterStats.hx.meta
@@ -5,7 +5,7 @@
   "language": "hscript",
   "pluginMetadata": {
     "com.fraymakers.FraymakersMetadata": {
-      "version": "0.1.2"
+      "version": "0.3.0"
     }
   },
   "plugins": [

--- a/Kung Fu Man/library/scripts/Character/HitboxStats.hx
+++ b/Kung Fu Man/library/scripts/Character/HitboxStats.hx
@@ -89,11 +89,15 @@
 		hitbox0: {damage: 10, knockbackGrowth: 65, baseKnockback: 60, hitstop: -1, selfHitstop: -1, hitstun: -1, reversibleAngle: false, angle: 85, limb:AttackLimb.FIST}
 	}, 
 
-	special_down: {
-		hitbox0: { damage:4, angle:25, baseKnockback: 70, knockbackGrowth: 0, hitstop: -1, selfHitstop: -1, reversibleAngle: false}
+	special_down_attack: {
+		hitbox0: {damage: 8, knockbackGrowth: 30, baseKnockback: 85, hitstop:-1, hitstopOffset:6, selfHitstop:-1, selfHitstopOffset:6, angle: 55, reversibleAngle: false}
 	}, 
-	special_down_air: {
-		hitbox0: { damage:4, angle:25, baseKnockback: 75, knockbackGrowth: 0, hitstop: -1, selfHitstop: -1, reversibleAngle: false}
+	special_down_air_attack: {
+		hitbox0: {damage: 8, knockbackGrowth: 30, baseKnockback: 85, hitstop:-1, hitstopOffset:6, selfHitstop:-1, selfHitstopOffset:6, angle: 55, reversibleAngle: false}
+	},
+
+	special_down_clutch_attack: {
+		hitbox0: {damage: 8, knockbackGrowth: 30, baseKnockback: 85, hitstop:-1, hitstopOffset:6, selfHitstop:-1, selfHitstopOffset:6, angle: 55, reversibleAngle: false}
 	},
 
 	//SUPERS


### PR DESCRIPTION
## Summary
Updated special_down to now be a chargeable move that scales the attacks speed and damage based on how long the move was held. This introduces a few new animations, special_down_loop, special_down_air_loop, special_down_attack, special_down_air_attack, and special_down_clutch_attack. Clutch attack is initiated by holding the clutch button during the move which adds slideOff: true and has no landing lag (KFM Ultra Wave Dash) Also adjusted hitbox data and the move now grabs the opponent to help with connecting the hit.

## Changes
- special_down is now chargeable both in the air and on the ground. The attacks distance (speed) and damage scales with the amount charged.
- Added new animations for charging the attack.
- Gravity of the air version is reduced to .1 so that the user floats during the charge. This makes it a recovery option.
- Holding clutch during either charge gives the clutch version that has special properties.
- The attack now has a grab box instead of an initial hitbox, this makes connecting the hit more consistent. (It was hard to get to hits to connect with varying speed)
- Cleaned up code related to the move and removed extra lines of code.

## Animations Changed
- speical_down
- special_down_air
## Animations Added
- special_down_loop
- special_down_air_loop
- special_down_attack
- special_down_air_attack
- special_down_clutch_attack